### PR TITLE
Add footer with social icons

### DIFF
--- a/index.html
+++ b/index.html
@@ -256,7 +256,27 @@
           <summary>Υπάρχει χώρος στάθμευσης;</summary>
           <p>Δημόσιος δωρεάν χώρος στάθμευσης στη γειτονιά — συνήθως εύκολος.</p>
         </details>
-        <details>
+      </div>
+    </div>
+  </section>
+
+  <footer>
+    <div class="container foot">
+      <small>© 2024 Hidden Pearl Dafnis</small>
+      <div class="social" aria-label="Κοινωνικά Δίκτυα">
+        <a class="icon" href="#" aria-label="Facebook" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M22 12.06C22 6.5 17.52 2 12 2S2 6.5 2 12.06c0 5.01 3.66 9.16 8.44 9.94v-7.03H7.9v-2.91h2.54V9.41c0-2.5 1.49-3.89 3.77-3.89 1.09 0 2.23.2 2.23.2v2.45h-1.25c-1.23 0-1.62.76-1.62 1.54v1.86h2.77l-.44 2.91h-2.33v7.03C18.34 21.22 22 17.07 22 12.06Z" fill="#1877F2"/>
+          </svg>
+        </a>
+        <a class="icon" href="#" aria-label="Instagram" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M7 2h10a5 5 0 0 1 5 5v10a5 5 0 0 1-5 5H7a5 5 0 0 1-5-5V7a5 5 0 0 1 5-5Zm0 2a3 3 0 0 0-3 3v10a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3H7Zm5 3.5a5.5 5.5 0 1 1 0 11 5.5 5.5 0 0 1 0-11Zm0 2a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7Zm5.75-.25a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5Z" fill="#E1306C"/>
+          </svg>
+        </a>
+      </div>
+    </div>
+  </footer>
 
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add footer matching header color with Facebook and Instagram icons
- close FAQ section markup

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6e77da4c88320970ffe89746d08b1