### PR TITLE
Add brand footer with contact details and social links

### DIFF
--- a/index.html
+++ b/index.html
@@ -106,6 +106,9 @@
     footer{background: var(--brand); padding: 36px 0; margin-top:56px}
     .foot{display:flex; gap:16px; align-items:center; justify-content:space-between; flex-wrap:wrap}
     .foot small{opacity:.8}
+    footer .contact{flex:1}
+    footer .logo{margin-inline:auto; display:flex; align-items:center; gap:12px; text-align:center}
+    footer .social{flex:1; justify-content:flex-end}
 
     /* Responsive */
     @media (max-width: 920px){
@@ -269,7 +272,45 @@
       </div>
     </div>
   </section>
-
+  <!-- FOOTER -->
+  <footer>
+    <div class="container foot">
+      <div class="contact">
+        <small>
+          <strong>Διεύθυνση:</strong> Γυμναστηρίου 26, Δάφνη Αττικής 172 35<br />
+          <strong>Τηλέφωνο:</strong> <a href="tel:6979299999">697 929 9999</a>
+        </small>
+      </div>
+      <div class="logo" aria-label="Λογότυπο Hidden Pearl Dafnis">
+        <svg viewBox="0 0 48 48" aria-hidden="true" width="36" height="36">
+          <defs>
+            <radialGradient id="pearl-footer" cx="50%" cy="40%" r="60%">
+              <stop offset="0%" stop-color="#ffffff"/>
+              <stop offset="60%" stop-color="#e8f9f7"/>
+              <stop offset="100%" stop-color="#c3eee8"/>
+            </radialGradient>
+          </defs>
+          <circle cx="24" cy="24" r="14" fill="url(#pearl-footer)" stroke="#1f2937" stroke-opacity=".15" />
+        </svg>
+        <div>
+          <strong>Hidden Pearl Dafnis</strong>
+          <span>Boutique Apartment</span>
+        </div>
+      </div>
+      <div class="social" aria-label="Κοινωνικά Δίκτυα">
+        <a id="facebookLinkFooter" class="icon" href="#" aria-label="Facebook" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M22 12.06C22 6.5 17.52 2 12 2S2 6.5 2 12.06c0 5.01 3.66 9.16 8.44 9.94v-7.03H7.9v-2.91h2.54V9.41c0-2.5 1.49-3.89 3.77-3.89 1.09 0 2.23.2 2.23.2v2.45h-1.25c-1.23 0-1.62.76-1.62 1.54v1.86h2.77l-.44 2.91h-2.33v7.03C18.34 21.22 22 17.07 22 12.06Z" fill="#1877F2"/>
+          </svg>
+        </a>
+        <a id="instagramLinkFooter" class="icon" href="#" aria-label="Instagram" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M7 2h10a5 5 0 0 1 5 5v10a5 5 0 0 1-5 5H7a5 5 0 0 1-5-5V7a5 5 0 0 1 5-5Zm0 2a3 3 0 0 0-3 3v10a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3H7Zm5 3.5a5.5 5.5 0 1 1 0 11 5.5 5.5 0 0 1 0-11Zm0 2a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7Zm5.75-.25a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5Z" fill="#E1306C"/>
+          </svg>
+        </a>
+      </div>
+    </div>
+  </footer>
 
 </body>
 <script>
@@ -297,6 +338,14 @@
     }
     prev.addEventListener('click',()=>goToSlide(index-1));
     next.addEventListener('click',()=>goToSlide(index+1));
+  })();
+  (function(){
+    const fb=document.getElementById('facebookLink');
+    const ig=document.getElementById('instagramLink');
+    const fbF=document.getElementById('facebookLinkFooter');
+    const igF=document.getElementById('instagramLinkFooter');
+    if(fb&&fbF) fbF.href=fb.href;
+    if(ig&&igF) igF.href=ig.href;
   })();
 </script>
 </html>


### PR DESCRIPTION
## Summary
- add footer matching header color with contact address and phone
- center brand logo and align social icons right
- sync footer social URLs with header links via script

## Testing
- `npx --yes prettier@latest --check index.html` *(fails: 403 Forbidden)*
- `npm test` *(fails: no package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6eba5fad883209b5f554178efd63b