### PR TITLE
Add header logo image

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,16 +127,7 @@
   <header>
     <div class="container nav">
       <div class="logo" aria-label="Λογότυπο Hidden Pearl Dafnis" style="display:flex;align-items:center;gap:12px">
-  <svg viewBox="0 0 48 48" aria-hidden="true" width="36" height="36">
-    <defs>
-      <radialGradient id="pearl" cx="50%" cy="40%" r="60%">
-        <stop offset="0%" stop-color="#ffffff"/>
-        <stop offset="60%" stop-color="#e8f9f7"/>
-        <stop offset="100%" stop-color="#c3eee8"/>
-      </radialGradient>
-    </defs>
-    <circle cx="24" cy="24" r="14" fill="url(#pearl)" stroke="#1f2937" stroke-opacity=".15" />
-  </svg>
+  <img src="logo/logo.png" alt="Hidden Pearl Dafnis logo" width="36" height="36" />
   <div>
     <strong>Hidden Pearl Dafnis</strong>
     <span>Boutique Apartment</span>


### PR DESCRIPTION
## Summary
- Display site logo image from `logo/logo.png` in the header instead of the inline SVG

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6efc195bc83209d6ce74ba349c94a