### PR TITLE
Add branded footer with contact info and social links

### DIFF
--- a/index.html
+++ b/index.html
@@ -265,6 +265,37 @@
   </section>
 
 
+  <!-- FOOTER -->
+  <footer>
+    <div class="container foot">
+      <div class="contact">
+        <small>
+          Διεύθυνση: Γυμναστηρίου 26, Δάφνη Αττικής 172 35<br />
+          Τηλέφωνο: <a href="tel:+306979299999">697 929 9999</a>
+        </small>
+      </div>
+      <div class="logo" aria-label="Λογότυπο Hidden Pearl Dafnis">
+        <img src="logo/logo.png" alt="Hidden Pearl Dafnis logo" width="56" height="56" />
+        <div>
+          <strong>Hidden Pearl Dafnis</strong>
+          <span>Boutique Apartment</span>
+        </div>
+      </div>
+      <div class="social" aria-label="Κοινωνικά Δίκτυα">
+        <a id="facebookLinkFooter" class="icon" href="#" aria-label="Facebook" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M22 12.06C22 6.5 17.52 2 12 2S2 6.5 2 12.06c0 5.01 3.66 9.16 8.44 9.94v-7.03H7.9v-2.91h2.54V9.41c0-2.5 1.49-3.89 3.77-3.89 1.09 0 2.23.2 2.23.2v2.45h-1.25c-1.23 0-1.62.76-1.62 1.54v1.86h2.77l-.44 2.91h-2.33v7.03C18.34 21.22 22 17.07 22 12.06Z" fill="#1877F2"/>
+          </svg>
+        </a>
+        <a id="instagramLinkFooter" class="icon" href="#" aria-label="Instagram" target="_blank" rel="noopener">
+          <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M7 2h10a5 5 0 0 1 5 5v10a5 5 0 0 1-5 5H7a5 5 0 0 1-5-5V7a5 5 0 0 1 5-5Zm0 2a3 3 0 0 0-3 3v10a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3H7Zm5 3.5a5.5 5.5 0 1 1 0 11 5.5 5.5 0 0 1 0-11Zm0 2a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7Zm5.75-.25a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5Z" fill="#E1306C"/>
+          </svg>
+        </a>
+      </div>
+    </div>
+  </footer>
+
 </body>
 <script>
   (function(){


### PR DESCRIPTION
## Summary
- add responsive footer matching header color with contact address and phone
- center brand logo and add Facebook/Instagram icons mirroring header links

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f338a1a48320af8b31e9111d02b7