### PR TITLE
Add map section below FAQs

### DIFF
--- a/index.html
+++ b/index.html
@@ -264,6 +264,15 @@
     </div>
   </section>
 
+  <!-- MAP -->
+  <section id="map" aria-labelledby="mapTitle">
+    <div class="container">
+      <h2 id="mapTitle" class="section-title">Χάρτης</h2>
+      <div class="map-wrap">
+        <iframe src="https://www.google.com/maps/embed?pb=!1m18!1m12!1m3!1d3146.048540599186!2d23.734218776105607!3d37.952652571941165!2m3!1f0!2f0!3f0!3m2!1i1024!2i768!4f13.1!3m3!1m2!1s0x14a1bd86b54a93e9%3A0x36148de6ab28e962!2sHidden%20Pearl%20Dafnis!5e0!3m2!1sel!2sgr!4v1756817369047!5m2!1sel!2sgr" width="600" height="450" style="border:0;" allowfullscreen="" loading="lazy" referrerpolicy="no-referrer-when-downgrade"></iframe>
+      </div>
+    </div>
+  </section>
 
 </body>
 <script>


### PR DESCRIPTION
## Summary
- Embed Google Maps iframe below the FAQ section

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6f34cb9d08320975e9fa5856035e6