### PR TITLE
Add automatic hero image slideshow

### DIFF
--- a/index.html
+++ b/index.html
@@ -59,7 +59,7 @@
     .cta{display:inline-flex; align-items:center; gap:10px; padding:14px 18px; background:var(--btn); color:var(--btn-text); border-radius:12px; box-shadow: var(--shadow); font-weight:700}
     .cta:focus{outline:none; box-shadow:0 0 0 4px var(--ring)}
     .hero-card{background:var(--card); border-radius: var(--radius); box-shadow: var(--shadow); overflow:hidden}
-    .hero-card img{display:block; width:100%; height:auto}
+    .hero-card img{display:block; width:100%; height:auto; transition:opacity 1s}
 
     /* Sections */
     section{padding: 56px 0}
@@ -170,7 +170,7 @@
         </a>
       </div>
       <div class="hero-card">
-        <img src="images/photo1.png" alt="Κομψό καθιστικό του Hidden Pearl Dafnis" loading="lazy" width="900" height="600" />
+        <img id="heroImage" src="images/hiddenpearl1.jpg" alt="Κομψό καθιστικό του Hidden Pearl Dafnis" width="900" height="600" />
       </div>
     </div>
   </main>
@@ -308,6 +308,20 @@
 
 </body>
 <script>
+  (function(){
+    const hero=document.getElementById('heroImage');
+    if(!hero) return;
+    const imgs=['images/hiddenpearl1.jpg','images/hiddenpearl2.jpg','images/hiddenpearl3.jpg'];
+    let i=0;
+    setInterval(()=>{
+      hero.style.opacity=0;
+      i=(i+1)%imgs.length;
+      setTimeout(()=>{
+        hero.src=imgs[i];
+        hero.style.opacity=1;
+      },500);
+    },4000);
+  })();
   (function(){
     const carousel=document.querySelector('#gal');
     if(!carousel) return;


### PR DESCRIPTION
## Summary
- rotate hero section images automatically between hiddenpearl1, hiddenpearl2 and hiddenpearl3
- add fade transition for smoother image changes

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bcadefb8d083208e3d57016da140c4