### PR TITLE
Add scroll-responsive header background

### DIFF
--- a/index.html
+++ b/index.html
@@ -38,10 +38,15 @@
     a{color:inherit; text-decoration:none}
     .container{max-width:1120px; margin-inline:auto; padding: 0 20px}
     header{
-      position: static;
+      position: sticky;
+      top:0;
       background: transparent;
       box-shadow: none;
       backdrop-filter: none;
+      transition: background-color .3s;
+    }
+    header.scrolled{
+      background: #492fde;
     }
     .nav{display:flex; align-items:center; justify-content:space-between; gap:16px; padding:14px 0}
     .logo{font-weight:800; letter-spacing:.2px}
@@ -308,10 +313,17 @@
   </footer>
 
 </body>
-<script>
-  (function(){
-    const hero=document.getElementById('heroImage');
-    if(!hero) return;
+  <script>
+    (function(){
+      const header=document.querySelector('header');
+      if(!header) return;
+      window.addEventListener('scroll',()=>{
+        header.classList.toggle('scrolled', window.scrollY > 0);
+      });
+    })();
+    (function(){
+      const hero=document.getElementById('heroImage');
+      if(!hero) return;
     const imgs=['images/hiddenpearl1.jpg','images/hiddenpearl2.jpg','images/hiddenpearl3.jpg'];
     let i=0;
     setInterval(()=>{


### PR DESCRIPTION
## Summary
- make header sticky and add transition class that applies brand background when scrolled
- add JavaScript listener to toggle header style based on scroll position

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd60ac52388320942a5126e1e5e0c3