### PR TITLE
Set hero image preview to 600x600

### DIFF
--- a/index.html
+++ b/index.html
@@ -62,8 +62,8 @@
     .hero p{font-size: clamp(16px, 1.4vw, 18px); color:var(--muted); margin:0 0 16px 0}
     .cta{display:inline-flex; align-items:center; gap:10px; padding:14px 18px; background:var(--btn); color:var(--btn-text); border-radius:12px; box-shadow: var(--shadow); font-weight:700}
     .cta:focus{outline:none; box-shadow:0 0 0 4px var(--ring)}
-    .hero-card{background:var(--card); border-radius: var(--radius); box-shadow: var(--shadow); overflow:hidden}
-    .hero-card img{display:block; width:100%; height:auto; transition:opacity 1s}
+    .hero-card{background:var(--card); border-radius: var(--radius); box-shadow: var(--shadow); overflow:hidden; width:600px; height:600px; max-width:100%}
+    .hero-card img{display:block; width:100%; height:100%; object-fit:cover; transition:opacity 1s}
 
     /* Sections */
     section{padding: 56px 0}
@@ -174,7 +174,7 @@
         </a>
       </div>
       <div class="hero-card">
-        <img id="heroImage" src="images/hiddenpearl1.jpg" alt="Κομψό καθιστικό του Hidden Pearl Dafnis" width="900" height="600" />
+        <img id="heroImage" src="images/hiddenpearl1.jpg" alt="Κομψό καθιστικό του Hidden Pearl Dafnis" width="600" height="600" />
       </div>
     </div>
   </main>


### PR DESCRIPTION
## Summary
- Force hero section card to display a 600x600 preview using `object-fit: cover`
- Set hero slideshow images to 600x600 dimensions

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd6a93051883208a61cd2d9a654c9e