### PR TITLE
Style CTA button with brand colors and hover outline

### DIFF
--- a/index.html
+++ b/index.html
@@ -61,9 +61,9 @@
     .hero .wrap{display:grid; grid-template-columns: 1.2fr 1fr; gap:32px; align-items:center}
     .hero h1{font-size: clamp(28px, 4.4vw, 48px); margin:0 0 12px 0}
     .hero p{font-size: clamp(16px, 1.4vw, 18px); color:var(--muted); margin:0 0 16px 0}
-    .cta{display:inline-flex; align-items:center; gap:10px; padding:14px 18px; background:var(--btn); color:var(--btn-text); border-radius:12px; box-shadow: var(--shadow); font-weight:700; transition: background .2s, color .2s}
-    .cta:hover{background:var(--brand); color:var(--brand-text)}
-    .cta:focus{outline:none; box-shadow:0 0 0 4px var(--ring)}
+    .cta{display:inline-flex; align-items:center; gap:10px; padding:14px 18px; background:var(--brand); color:var(--brand-text); border-radius:12px; box-shadow: var(--shadow); font-weight:700; outline:0; transition: background .2s, color .2s}
+    .cta:hover{background:var(--bg); color:var(--brand); outline:1px solid #000}
+    .cta:focus{outline:0; box-shadow:0 0 0 4px var(--ring)}
     .hero-card{background:var(--card); border-radius: var(--radius); box-shadow: var(--shadow); overflow:hidden; width:600px; height:600px; max-width:100%}
     .hero-card img{display:block; width:100%; height:100%; object-fit:cover; transition:opacity 1s}
 


### PR DESCRIPTION
## Summary
- Make CTA button use brand background and text colors by default and invert them on hover.
- Add a thin black outline on CTA hover for better contrast.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd7bb30cb88320b53f784e367ad1fc