### PR TITLE
Add responsive mobile navigation menu

### DIFF
--- a/index.html
+++ b/index.html
@@ -50,11 +50,14 @@
     .nav{display:flex; align-items:center; justify-content:space-between; gap:16px; padding:14px 0}
     .logo{font-weight:800; letter-spacing:.2px}
     .logo span{display:block; font-size:12px; opacity:.8}
+    nav{position:relative}
     nav ul{display:flex; gap:18px; list-style:none; padding:0; margin:0}
     nav a{font-weight:600}
     .social{display:flex; align-items:center; gap:10px}
     .icon{display:inline-flex; width:28px; height:28px; align-items:center; justify-content:center; border-radius:999px; background:#ffffff; box-shadow: inset 0 0 0 1px rgba(0,0,0,.08)}
     .icon svg{width:16px; height:16px}
+    .menu-btn{display:none; background:none; border:0; color:inherit; cursor:pointer}
+    .menu-btn svg{width:28px; height:28px}
 
     /* Hero */
     .hero{padding: clamp(48px, 8vw, 96px) 0}
@@ -123,7 +126,11 @@
       .hero-card{order:-1}
     }
     @media (max-width: 640px){
-      nav ul{display:none}
+      nav{margin-left:auto}
+      .social{display:none}
+      .menu-btn{display:inline-flex}
+      nav ul{display:none; position:absolute; top:100%; right:0; background:var(--brand); flex-direction:column; gap:10px; padding:10px 14px; border-radius:12px; box-shadow:var(--shadow); margin:8px 0 0 0}
+      nav.open ul{display:flex}
       .features{grid-template-columns: 1fr}
     }
   </style>
@@ -141,6 +148,11 @@
 </div>
 
       <nav aria-label="Κύρια Πλοήγηση">
+        <button class="menu-btn" aria-expanded="false" aria-label="Μενού">
+          <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+          </svg>
+        </button>
         <ul>
           <li><a href="#home">Αρχική</a></li>
           <li><a href="#gallery">Φωτογραφίες</a></li>
@@ -360,6 +372,15 @@
     const igF=document.getElementById('instagramLinkFooter');
     if(fb&&fbF) fbF.href=fb.href;
     if(ig&&igF) igF.href=ig.href;
+  })();
+  (function(){
+    const btn=document.querySelector('.menu-btn');
+    const nav=document.querySelector('header nav');
+    if(!btn||!nav) return;
+    btn.addEventListener('click',()=>{
+      const open=nav.classList.toggle('open');
+      btn.setAttribute('aria-expanded',open);
+    });
   })();
 </script>
 </html>


### PR DESCRIPTION
## Summary
- add hamburger menu button for small screens
- style navigation and hide social icons on narrow viewports
- enable JavaScript toggle for mobile navigation

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd821176308320b000b8d96ff50cc4