### PR TITLE
Add mobile off-canvas drawer

### DIFF
--- a/drawer.js
+++ b/drawer.js
@@ -1,0 +1,76 @@
+// Mobile off-canvas drawer logic
+(function(){
+  const drawer = document.querySelector('.drawer');
+  const overlay = document.querySelector('.overlay');
+  const toggleBtn = document.querySelector('[aria-controls="drawer"]');
+  if(!drawer || !overlay || !toggleBtn) return;
+
+  const closeBtn = drawer.querySelector('.drawer__close');
+  const focusableSelectors = 'a[href], button:not([disabled]), textarea, input, select, [tabindex]:not([tabindex="-1"])';
+  let lastFocused = null;
+
+  function openDrawer(){
+    lastFocused = document.activeElement;
+    drawer.classList.add('is-open');
+    overlay.classList.add('is-open');
+    document.body.classList.add('drawer-open');
+    toggleBtn.setAttribute('aria-expanded','true');
+    const firstFocusable = drawer.querySelector(focusableSelectors);
+    firstFocusable && firstFocusable.focus();
+  }
+
+  function closeDrawer(){
+    drawer.classList.remove('is-open');
+    overlay.classList.remove('is-open');
+    document.body.classList.remove('drawer-open');
+    toggleBtn.setAttribute('aria-expanded','false');
+    if(lastFocused) lastFocused.focus();
+  }
+
+  toggleBtn.addEventListener('click', () => {
+    const open = drawer.classList.contains('is-open');
+    open ? closeDrawer() : openDrawer();
+  });
+
+  closeBtn && closeBtn.addEventListener('click', closeDrawer);
+  overlay.addEventListener('click', closeDrawer);
+  drawer.querySelectorAll('a').forEach(link => link.addEventListener('click', closeDrawer));
+
+  document.addEventListener('keydown', (e) => {
+    if(e.key === 'Escape' && drawer.classList.contains('is-open')){
+      closeDrawer();
+    }
+  });
+
+  // focus trap
+  drawer.addEventListener('keydown', (e) => {
+    if(e.key !== 'Tab') return;
+    const focusable = Array.from(drawer.querySelectorAll(focusableSelectors));
+    if(focusable.length === 0) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if(e.shiftKey && document.activeElement === first){
+      e.preventDefault();
+      last.focus();
+    }else if(!e.shiftKey && document.activeElement === last){
+      e.preventDefault();
+      first.focus();
+    }
+  });
+
+  // accordion menus
+  drawer.querySelectorAll('.drawer__nav button[aria-controls]').forEach(btn => {
+    const menu = document.getElementById(btn.getAttribute('aria-controls'));
+    if(!menu) return;
+    btn.addEventListener('click', () => {
+      const expanded = btn.getAttribute('aria-expanded') === 'true';
+      btn.setAttribute('aria-expanded', String(!expanded));
+      menu.classList.toggle('is-open', !expanded);
+      if(!expanded){
+        menu.style.maxHeight = menu.scrollHeight + 'px';
+      }else{
+        menu.style.maxHeight = 0;
+      }
+    });
+  });
+})();

--- a/style.css
+++ b/style.css
@@ -1,1 +1,186 @@
+:root {
+  --drawer-width: 300px;
+  --drawer-bg: #ffffff;
+  --brand: #492FDE;
+  --overlay-bg: rgba(0, 0, 0, 0.5);
+  --transition: 300ms;
+}
 
+@media (max-width: 768px) {
+  /* base transition for parallax */
+  body {
+    transition: transform var(--transition) ease;
+  }
+  body.drawer-open {
+    overflow: hidden;
+    transform: translateX(10px);
+  }
+
+  /* overlay */
+  .overlay {
+    position: fixed;
+    inset: 0;
+    background: var(--overlay-bg);
+    opacity: 0;
+    pointer-events: none;
+    transition: opacity var(--transition) ease;
+    z-index: 1000;
+  }
+  .overlay.is-open {
+    opacity: 1;
+    pointer-events: auto;
+  }
+
+  /* drawer panel */
+  .drawer {
+    position: fixed;
+    top: 0;
+    left: 0;
+    height: 100vh;
+    width: var(--drawer-width);
+    max-width: 80%;
+    background: var(--drawer-bg);
+    box-shadow: 2px 0 8px rgba(0,0,0,.1);
+    transform: translateX(-100%);
+    transition: transform var(--transition) ease;
+    z-index: 1100;
+    display: flex;
+    flex-direction: column;
+  }
+  .drawer.is-open {
+    transform: translateX(0);
+  }
+
+  .drawer__header {
+    position: relative;
+    padding: 16px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+  }
+  .drawer__close {
+    position: absolute;
+    left: 16px;
+    top: 16px;
+    background: none;
+    border: 0;
+    font-size: 24px;
+    line-height: 1;
+    cursor: pointer;
+    color: var(--brand);
+  }
+  .drawer__logo {
+    transition: transform var(--transition) ease;
+    transform: scale(0.9);
+  }
+  .drawer.is-open .drawer__logo {
+    transform: scale(1);
+  }
+
+  .drawer__nav {
+    flex: 1;
+    overflow-y: auto;
+    padding: 16px;
+  }
+  .drawer__nav ul {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+  }
+  .drawer__nav a,
+  .drawer__nav button {
+    width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    padding: 12px 0;
+    background: none;
+    border: 0;
+    font: inherit;
+    color: inherit;
+    cursor: pointer;
+  }
+  .drawer__nav button .caret {
+    margin-left: 8px;
+    transition: transform .2s;
+  }
+  .drawer__nav button[aria-expanded="true"] .caret {
+    transform: rotate(180deg);
+  }
+  .drawer__submenu {
+    max-height: 0;
+    overflow: hidden;
+    transition: max-height var(--transition) ease;
+  }
+  .drawer__submenu.is-open {
+    /* max-height is set inline via JS for smooth height transition */
+  }
+
+  .drawer__lang,
+  .drawer__cta,
+  .drawer__footer {
+    padding: 16px;
+    border-top: 1px solid rgba(0,0,0,.1);
+  }
+
+  .drawer__lang {
+    display: flex;
+    justify-content: center;
+    gap: 8px;
+  }
+  .drawer__lang button {
+    background: none;
+    border: 0;
+    cursor: pointer;
+  }
+
+  .drawer__cta {
+    display: flex;
+    gap: 8px;
+    justify-content: space-between;
+  }
+  .drawer__cta a {
+    flex: 1;
+    text-align: center;
+    padding: 10px;
+    border-radius: 8px;
+    background: var(--brand);
+    color: #fff;
+    font-weight: 600;
+    transition: background .2s;
+  }
+  .drawer__cta a:hover,
+  .drawer__cta a:focus {
+    background: #604bf1;
+  }
+
+  .drawer__footer {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 12px;
+  }
+  .drawer__footer a {
+    color: var(--brand);
+  }
+  .drawer__social {
+    display: flex;
+    gap: 12px;
+  }
+  .drawer__social a {
+    width: 32px;
+    height: 32px;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    border-radius: 50%;
+    background: rgba(73,47,222,0.1);
+    transition: background .2s, color .2s;
+    color: var(--brand);
+  }
+  .drawer__social a:hover,
+  .drawer__social a:focus {
+    background: var(--brand);
+    color: #fff;
+  }
+}


### PR DESCRIPTION
## Summary
- add responsive mobile drawer styles with overlay, parallax, CTA areas and social icons
- implement vanilla JS for drawer toggle, focus trap and accordion submenus

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bd9e9812248320b958ce6ec6a4dbcb