### PR TITLE
Add responsive drawer navigation skeleton

### DIFF
--- a/drawer.html
+++ b/drawer.html
@@ -1,0 +1,114 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Responsive Navigation Skeleton</title>
+</head>
+<body>
+  <!-- Header -->
+  <header class="site-header">
+    <div class="site-header__inner">
+      <a class="site-logo" href="/">Logo</a>
+
+      <!-- Desktop Navigation -->
+      <nav class="site-nav" aria-label="Primary">
+        <ul>
+          <li><a href="#">Home</a></li>
+          <li><a href="#">About</a></li>
+          <li><a href="#">Services</a></li>
+          <li><a href="#">Contact</a></li>
+        </ul>
+      </nav>
+
+      <!-- Mobile Hamburger -->
+      <button
+        class="hamburger"
+        aria-label="Open navigation"
+        aria-controls="drawer"
+        aria-expanded="false"
+      >
+        <span class="hamburger__line"></span>
+        <span class="hamburger__line"></span>
+        <span class="hamburger__line"></span>
+      </button>
+    </div>
+  </header>
+
+  <!-- Drawer -->
+  <div id="drawer" class="drawer" aria-hidden="true">
+    <div class="drawer__overlay" aria-hidden="true"></div>
+
+    <aside class="drawer__panel" role="dialog" aria-modal="true">
+      <!-- Top: Close + Logo -->
+      <div class="drawer__top">
+        <button class="drawer__close" aria-label="Close navigation">&times;</button>
+        <a href="/" class="drawer__logo">Logo</a>
+      </div>
+
+      <!-- Middle: Navigation with Accordions -->
+      <nav class="drawer__nav" aria-label="Mobile">
+        <ul>
+          <li class="drawer__item">
+            <button
+              class="drawer__toggle"
+              aria-expanded="false"
+              aria-controls="submenu-1"
+            >
+              Menu Item 1
+            </button>
+            <ul id="submenu-1" class="drawer__submenu" hidden>
+              <li><a href="#">Sub Item 1</a></li>
+              <li><a href="#">Sub Item 2</a></li>
+            </ul>
+          </li>
+
+          <li class="drawer__item">
+            <button
+              class="drawer__toggle"
+              aria-expanded="false"
+              aria-controls="submenu-2"
+            >
+              Menu Item 2
+            </button>
+            <ul id="submenu-2" class="drawer__submenu" hidden>
+              <li><a href="#">Sub Item A</a></li>
+              <li><a href="#">Sub Item B</a></li>
+            </ul>
+          </li>
+
+          <li class="drawer__item"><a href="#">Menu Item 3</a></li>
+        </ul>
+      </nav>
+
+      <!-- Language Switcher -->
+      <div class="drawer__lang-switcher" role="group" aria-label="Language">
+        <button class="lang lang--gr" aria-label="Greek">
+          <img src="gr-flag.svg" alt="Greek flag" />
+        </button>
+        <button class="lang lang--en" aria-label="English">
+          <img src="en-flag.svg" alt="English flag" />
+        </button>
+      </div>
+
+      <!-- CTA Section -->
+      <div class="drawer__cta">
+        <a href="#" class="cta cta--whatsapp">WhatsApp</a>
+        <a href="#" class="cta cta--viber">Viber</a>
+        <a href="#" class="cta cta--messenger">Messenger</a>
+      </div>
+
+      <!-- Footer -->
+      <footer class="drawer__footer">
+        <a href="mailto:info@example.com" class="drawer__email">
+          <span class="icon icon--envelope"></span>
+          info@example.com
+        </a>
+        <div class="drawer__social">
+          <a href="#" class="social social--facebook" aria-label="Facebook"></a>
+          <a href="#" class="social social--instagram" aria-label="Instagram"></a>
+        </div>
+      </footer>
+    </aside>
+  </div>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- add HTML skeleton for responsive off-canvas drawer navigation with desktop nav, mobile hamburger, accordion submenus, language switcher, and CTA section

## Testing
- `npm test` *(fails: ENOENT: no such file or directory, open 'package.json')*

------
https://chatgpt.com/codex/tasks/task_e_68bd9da4bd6483209ddb60639844f85b