### PR TITLE
Use white text for header and footer

### DIFF
--- a/index.html
+++ b/index.html
@@ -29,7 +29,7 @@
     :root{
       --bg:#d9d9d9;          /* page background */
       --brand:#43D9D7;       /* header & footer */
-      --brand-text:#f1e6d4;  /* header & footer text */
+      --brand-text:#fff;     /* header & footer text */
       --text:#1f2937;        /* slate-800 */
       --muted:#6b7280;       /* slate-500 */
       --card:#ffffff;

--- a/style.css
+++ b/style.css
@@ -26,6 +26,7 @@ body {
   top: 0;
   z-index: 10000;
   background: rgba(67, 217, 215, 0.6);
+  color: #fff;
 }
 
 body.scrolled .site-header {
@@ -196,6 +197,7 @@ section[id] {
     flex-direction: column;
     align-items: center;
     gap: 0.5rem;
+    color: #fff;
   }
   .drawer__email {
     display: flex;


### PR DESCRIPTION
## Summary
- Set `--brand-text` variable to pure white for consistent header and footer text
- Ensure header and drawer footer components inherit white text color

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6c51319d88320807ab3909ad338cd