### PR TITLE
Shift hero titles down on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -157,6 +157,7 @@
       .menu-btn{display:inline-flex}
       nav ul{display:none; position:absolute; top:100%; right:0; background:var(--brand); flex-direction:column; gap:10px; padding:10px 14px; border-radius:12px; box-shadow:var(--shadow); margin:8px 0 0 0}
       nav.open ul{display:flex}
+      .hero-content{transform: translateY(4rem);}
       .features{grid-template-columns: 1fr}
     }
   </style>


### PR DESCRIPTION
## Summary
- offset hero section text downward on small screens for better spacing

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c6fd0496048320bef75d694bcd581f