### PR TITLE
Adjust CTA colors to match header and hover states

### DIFF
--- a/index.html
+++ b/index.html
@@ -94,8 +94,8 @@
     }
     .hero h1{font-size: clamp(28px, 4.4vw, 48px); margin:0 0 12px 0; text-shadow:0 1px 4px rgba(0,0,0,.4)}
     .hero p{font-size: clamp(16px, 1.4vw, 18px); margin:0 0 16px 0; color:rgba(255,255,255,.9); text-shadow:0 1px 4px rgba(0,0,0,.4)}
-    .cta{display:inline-flex; align-items:center; gap:10px; padding:14px 18px; background:var(--bg); color:var(--brand); border-radius:12px; box-shadow: var(--shadow); font-weight:700; outline:1px solid #000; transition: background .2s, color .2s; position:relative; z-index:1}
-    .cta:hover{background:var(--brand); color:var(--brand-text); outline:0}
+    .cta{display:inline-flex; align-items:center; gap:10px; padding:14px 18px; background:var(--brand); color:var(--brand-text); border-radius:12px; box-shadow: var(--shadow); font-weight:700; outline:1px solid transparent; transition: background .2s, color .2s; position:relative; z-index:1}
+    .cta:hover{background:var(--bg); color:var(--brand)}
     .cta:focus{outline:0; box-shadow:0 0 0 4px var(--ring)}
 
     /* Sections */

--- a/style.css
+++ b/style.css
@@ -188,6 +188,13 @@ section[id] {
     padding: 0.5rem 1rem;
     border-radius: 4px;
     text-decoration: none;
+    transition: background-color 0.2s ease, color 0.2s ease;
+  }
+
+  .drawer__cta-btn:hover,
+  .drawer__cta-btn:focus {
+    background: #d9d9d9;
+    color: var(--accent);
   }
 
   /* Footer */


### PR DESCRIPTION
## Summary
- set CTA buttons on the main page to use the header color with white text by default and swap colors on hover
- extend drawer CTA buttons with matching color transitions for normal and hover states

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c855cb31d0832098a982a47d065010