### PR TITLE
Add mobile drawer navigation with CTA and contact info

### DIFF
--- a/index.html
+++ b/index.html
@@ -58,9 +58,14 @@
     .nav{display:flex; align-items:center; justify-content:space-between; gap:16px; padding:14px 0}
     .logo{font-weight:800; letter-spacing:.2px}
     .logo span{display:block; font-size:12px; opacity:.8}
-    nav{position:relative}
+    header nav{position:relative; display:flex; align-items:center; gap:16px}
     nav ul{display:flex; gap:18px; list-style:none; padding:0; margin:0}
     nav a{font-weight:600}
+    .nav-panel{display:flex; align-items:center; gap:18px}
+    .nav-backdrop{display:none}
+    .nav-cta,.drawer-contact,.drawer-social{display:none}
+    .drawer-contact{font-size:14px; line-height:1.5}
+    .drawer-contact a{color:inherit; display:block}
     .social{display:flex; align-items:center; gap:10px}
     .icon{display:inline-flex; width:28px; height:28px; align-items:center; justify-content:center; border-radius:999px; background:#ffffff; box-shadow: inset 0 0 0 1px rgba(0,0,0,.08)}
     .icon svg{width:16px; height:16px}
@@ -156,12 +161,77 @@
 
     /* Responsive */
     @media (max-width: 767px) {
+      .nav > .social{display:none}
+      .menu-btn{display:inline-flex; align-items:center; justify-content:center; padding:4px}
+      .nav-panel{
+        position:fixed;
+        top:0;
+        left:0;
+        bottom:0;
+        width:min(82vw, 320px);
+        background:var(--card);
+        color:var(--text);
+        flex-direction:column;
+        align-items:flex-start;
+        gap:24px;
+        padding:96px 24px 36px;
+        transform:translateX(-110%);
+        transition:transform .3s ease;
+        box-shadow:12px 0 32px rgba(15,23,42,.24);
+        z-index:1100;
+        overflow-y:auto;
+      }
+      nav.open .nav-panel{transform:translateX(0)}
+      .nav-backdrop{
+        display:block;
+        position:fixed;
+        inset:0;
+        background:rgba(17,24,39,.45);
+        opacity:0;
+        pointer-events:none;
+        transition:opacity .3s ease;
+        z-index:1050;
+      }
+      nav.open .nav-backdrop{
+        opacity:1;
+        pointer-events:auto;
+      }
+      nav ul{
+        flex-direction:column;
+        gap:18px;
+        width:100%;
+      }
+      nav ul a{
+        color:inherit;
+        font-size:16px;
+        font-weight:700;
+        display:block;
+        padding:4px 0;
+      }
+      .nav-cta{
+        display:inline-flex;
+        width:100%;
+        justify-content:center;
+      }
+      .nav-cta svg{flex-shrink:0}
+      .drawer-contact{
+        display:flex;
+        flex-direction:column;
+        gap:8px;
+        width:100%;
+      }
+      .drawer-contact a{font-weight:600}
+      .drawer-social{
+        display:flex;
+        gap:10px;
+      }
       .features {
         grid-template-columns: 1fr;
       }
       .reviews {
         grid-template-columns: 1fr;
       }
+      body.no-scroll{overflow:hidden}
     }
     </style>
 </head>
@@ -178,7 +248,7 @@
 </div>
 
       <nav aria-label="Κύρια Πλοήγηση">
-        <button class="menu-btn" aria-expanded="false" aria-label="Μενού">
+        <button class="menu-btn" type="button" aria-expanded="false" aria-controls="mobileMenu" aria-label="Άνοιγμα μενού">
           <svg class="hamburger" viewBox="0 0 24 24" fill="none" aria-hidden="true">
             <path d="M4 6h16M4 12h16M4 18h16" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
           </svg>
@@ -186,13 +256,34 @@
             <path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
           </svg>
         </button>
-        <ul>
-          <li><a href="#home">Αρχική</a></li>
-          <li><a href="#gallery">Φωτογραφίες</a></li>
-          <li><a href="#faqs">Συχνές Ερωτήσεις</a></li>
-          <li><a href="#location">Τοποθεσία</a></li>
-          <li><a href="#contact">Επικοινωνία</a></li>
-        </ul>
+        <div class="nav-backdrop" aria-hidden="true"></div>
+        <div id="mobileMenu" class="nav-panel">
+          <ul class="nav-links">
+            <li><a href="#about">Περιγραφή καταλύματος</a></li>
+            <li><a href="#gallery">Gallery</a></li>
+            <li><a href="#faqs">Συχνές ερωτήσεις</a></li>
+          </ul>
+          <a class="cta nav-cta" href="https://hiddenpearldafnis.setmore.com" target="_blank" rel="noopener">
+            Κλείσε Διαμονή
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" aria-hidden="true"><path d="M5 12h14M13 5l7 7-7 7" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/></svg>
+          </a>
+          <div class="drawer-contact" aria-label="Στοιχεία επικοινωνίας">
+            <a class="contact-link" href="mailto:hiddenpearldafnis@gmail.com">hiddenpearldafnis@gmail.com</a>
+            <a class="contact-link" href="tel:+306979299999">697 929 9999</a>
+          </div>
+          <div class="social drawer-social" aria-label="Κοινωνικά Δίκτυα">
+            <a id="facebookLinkDrawer" class="icon" href="#" aria-label="Facebook" target="_blank" rel="noopener">
+              <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M22 12.06C22 6.5 17.52 2 12 2S2 6.5 2 12.06c0 5.01 3.66 9.16 8.44 9.94v-7.03H7.9v-2.91h2.54V9.41c0-2.5 1.49-3.89 3.77-3.89 1.09 0 2.23.2 2.23.2v2.45h-1.25c-1.23 0-1.62.76-1.62 1.54v1.86h2.77l-.44 2.91h-2.33v7.03C18.34 21.22 22 17.07 22 12.06Z" fill="#1877F2"/>
+              </svg>
+            </a>
+            <a id="instagramLinkDrawer" class="icon" href="#" aria-label="Instagram" target="_blank" rel="noopener">
+              <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
+                <path d="M7 2h10a5 5 0 0 1 5 5v10a5 5 0 0 1-5 5H7a5 5 0 0 1-5-5V7a5 5 0 0 1 5-5Zm0 2a3 3 0 0 0-3 3v10a3 3 0 0 0 3 3h10a3 3 0 0 0 3-3V7a3 3 0 0 0-3-3H7Zm5 3.5a5.5 5.5 0 1 1 0 11 5.5 5.5 0 0 1 0-11Zm0 2a3.5 3.5 0 1 0 0 7 3.5 3.5 0 0 0 0-7Zm5.75-.25a1.25 1.25 0 1 1 0 2.5 1.25 1.25 0 0 1 0-2.5Z" fill="#E1306C"/>
+              </svg>
+            </a>
+          </div>
+        </div>
       </nav>
       <div class="social" aria-label="Κοινωνικά Δίκτυα">
         <a id="facebookLink" class="icon" href="#" aria-label="Facebook" target="_blank" rel="noopener">
@@ -441,30 +532,55 @@
     const ig=document.getElementById('instagramLink');
     const fbF=document.getElementById('facebookLinkFooter');
     const igF=document.getElementById('instagramLinkFooter');
-    if(fb&&fbF) fbF.href=fb.href;
-    if(ig&&igF) igF.href=ig.href;
+    const fbD=document.getElementById('facebookLinkDrawer');
+    const igD=document.getElementById('instagramLinkDrawer');
+    if(fb){
+      if(fbF) fbF.href=fb.href;
+      if(fbD) fbD.href=fb.href;
+    }
+    if(ig){
+      if(igF) igF.href=ig.href;
+      if(igD) igD.href=ig.href;
+    }
   })();
   (function(){
     const btn=document.querySelector('.menu-btn');
     const nav=document.querySelector('header nav');
     if(!btn||!nav) return;
-    const links=nav.querySelectorAll('a');
+    const drawer=nav.querySelector('.nav-panel');
+    const overlay=nav.querySelector('.nav-backdrop');
+    const links=drawer ? drawer.querySelectorAll('a') : nav.querySelectorAll('a');
+    const body=document.body;
     function closeMenu(){
+      if(!nav.classList.contains('open')) return;
       nav.classList.remove('open');
       btn.setAttribute('aria-expanded','false');
-      btn.setAttribute('aria-label','Μενού');
+      btn.setAttribute('aria-label','Άνοιγμα μενού');
+      body.classList.remove('no-scroll');
+    }
+    function openMenu(){
+      nav.classList.add('open');
+      btn.setAttribute('aria-expanded','true');
+      btn.setAttribute('aria-label','Κλείσιμο μενού');
+      body.classList.add('no-scroll');
     }
     btn.addEventListener('click',()=>{
-      const open=nav.classList.toggle('open');
-      btn.setAttribute('aria-expanded',open);
-      btn.setAttribute('aria-label', open ? 'Κλείσιμο' : 'Μενού');
+      if(nav.classList.contains('open')){
+        closeMenu();
+      }else{
+        openMenu();
+      }
     });
+    overlay?.addEventListener('click',closeMenu);
     links.forEach(link=>link.addEventListener('click',closeMenu));
     document.addEventListener('click',e=>{
       if(nav.classList.contains('open')&&!nav.contains(e.target)) closeMenu();
     });
     document.addEventListener('keydown',e=>{
       if(e.key==='Escape') closeMenu();
+    });
+    window.addEventListener('resize',()=>{
+      if(window.innerWidth>=768) closeMenu();
     });
   })();
 </script>


### PR DESCRIPTION
## Summary
- add a slide-in mobile drawer menu with booking CTA, contact details, and social icons
- update header styles so the hamburger button stays on the right and the drawer animates from the left on small screens
- enhance the menu script to manage the overlay, body scroll lock, and sync social links across header, drawer, and footer

## Testing
- Not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68c858b52750832084f4c8a4b067d598