### PR TITLE
Reduce mobile drawer CTA width

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,8 +210,9 @@
       }
       .nav-cta{
         display:inline-flex;
-        width:100%;
+        width:50%;
         justify-content:center;
+        align-self:center;
       }
       .nav-cta svg{flex-shrink:0}
       .drawer-contact{


### PR DESCRIPTION
## Summary
- shrink the hamburger menu CTA button to 50% width on mobile so it appears half as wide
- center the narrower CTA inside the drawer for balanced alignment

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68c85c7547ac83209fe9182c44a8ffad