### PR TITLE
Hide desktop CTA and header socials

### DIFF
--- a/index.html
+++ b/index.html
@@ -160,6 +160,10 @@
     footer .social{flex:1; justify-content:flex-end}
 
     /* Responsive */
+    @media (min-width: 768px) {
+      .nav-panel .nav-cta {display:none}
+      .nav > .social {display:none}
+    }
     @media (max-width: 767px) {
       .nav > .social{display:none}
       .menu-btn{display:inline-flex; align-items:center; justify-content:center; padding:4px}


### PR DESCRIPTION
## Summary
- hide the call-to-action button from the desktop navigation
- remove the duplicate social icons from the header on desktop screens

## Testing
- no tests were run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68c86286e6f08320a284bd59d6fa71a1