### PR TITLE
Make header and footer logos link to homepage

### DIFF
--- a/index.html
+++ b/index.html
@@ -269,13 +269,13 @@
   <!-- HEADER -->
   <header>
     <div class="container nav">
-      <div class="logo" aria-label="Λογότυπο Hidden Pearl Dafnis" style="display:flex;align-items:center;gap:12px">
-    <img src="logo/logo5.png" alt="Hidden Pearl Dafnis logo" width="112" height="112" />
-  <div>
-    <strong>Hidden Pearl Dafnis</strong>
-    <span>Boutique Apartment</span>
-  </div>
-</div>
+      <a class="logo" href="/" aria-label="Μετάβαση στην αρχική σελίδα Hidden Pearl Dafnis" style="display:flex;align-items:center;gap:12px">
+        <img src="logo/logo5.png" alt="Hidden Pearl Dafnis logo" width="112" height="112" />
+        <div>
+          <strong>Hidden Pearl Dafnis</strong>
+          <span>Boutique Apartment</span>
+        </div>
+      </a>
 
       <nav aria-label="Κύρια Πλοήγηση">
         <button class="menu-btn" type="button" aria-expanded="false" aria-controls="mobileMenu" aria-label="Άνοιγμα μενού">
@@ -500,13 +500,13 @@
           Τηλέφωνο: <a href="tel:+306979299999">697 929 9999</a>
         </small>
       </div>
-      <div class="logo" aria-label="Λογότυπο Hidden Pearl Dafnis">
+      <a class="logo" href="/" aria-label="Μετάβαση στην αρχική σελίδα Hidden Pearl Dafnis">
         <img src="logo/logo5.png" alt="Hidden Pearl Dafnis logo" width="112" height="112" />
         <div>
           <strong>Hidden Pearl Dafnis</strong>
           <span>Boutique Apartment</span>
         </div>
-      </div>
+      </a>
       <div class="social" aria-label="Κοινωνικά Δίκτυα">
         <a id="facebookLinkFooter" class="icon" href="#" aria-label="Facebook" target="_blank" rel="noopener">
           <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">


### PR DESCRIPTION
## Summary
- wrap the header and footer logo blocks with links that navigate to the homepage when clicked
- clarify the logo link purpose for assistive technology with updated aria-labels

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68c86956787c8320a22da3531062943f