### PR TITLE
Remove mobile drawer close button

### DIFF
--- a/index.html
+++ b/index.html
@@ -104,18 +104,6 @@
     nav ul{display:flex; gap:18px; list-style:none; padding:0; margin:0}
     nav a{font-weight:600}
     .nav-panel{display:flex; align-items:center; gap:18px}
-    .nav-close{
-      display:none;
-      align-items:center;
-      gap:8px;
-      background:none;
-      border:0;
-      color:inherit;
-      cursor:pointer;
-      font-weight:600;
-      font-size:14px;
-    }
-    .nav-close svg{width:18px; height:18px}
     .nav-backdrop{display:none}
     .nav-cta,.drawer-contact,.drawer-social{display:none}
     .drawer-contact{font-size:14px; line-height:1.5}
@@ -260,19 +248,6 @@
         box-shadow:var(--shadow);
       }
       nav.open .menu-btn:focus{box-shadow:0 0 0 3px var(--ring), var(--shadow)}
-      .nav-close{
-        display:inline-flex;
-        align-items:center;
-        justify-content:center;
-        padding:6px 12px;
-        margin-left:auto;
-        margin-bottom:8px;
-        background:rgba(15,23,42,.05);
-        border-radius:999px;
-        border:1px solid rgba(15,23,42,.12);
-      }
-      .nav-close span{font-size:14px}
-      .nav-close:focus{outline:0; box-shadow:0 0 0 3px var(--ring)}
       nav.open .nav-panel{transform:translateX(0)}
       .nav-backdrop{
         display:block;
@@ -354,12 +329,6 @@
         </button>
         <div class="nav-backdrop" aria-hidden="true"></div>
         <div id="mobileMenu" class="nav-panel">
-          <button class="nav-close" type="button" aria-label="Κλείσιμο μενού">
-            <svg viewBox="0 0 24 24" fill="none" aria-hidden="true">
-              <path d="M6 6l12 12M6 18L18 6" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
-            </svg>
-            <span>Κλείσιμο</span>
-          </button>
           <ul class="nav-links">
             <li><a href="#about">Περιγραφή καταλύματος</a></li>
             <li><a href="#gallery">Gallery</a></li>
@@ -652,7 +621,7 @@
     const drawer=nav.querySelector('.nav-panel');
     const overlay=nav.querySelector('.nav-backdrop');
     const links=drawer ? drawer.querySelectorAll('a') : nav.querySelectorAll('a');
-    const closeBtn=nav.querySelector('.nav-close');
+    const firstLink=links.length ? links[0] : null;
     const body=document.body;
     function closeMenu(){
       if(!nav.classList.contains('open')) return;
@@ -666,7 +635,7 @@
       btn.setAttribute('aria-expanded','true');
       btn.setAttribute('aria-label','Κλείσιμο μενού');
       body.classList.add('no-scroll');
-      closeBtn?.focus();
+      firstLink?.focus();
     }
     btn.addEventListener('click',()=>{
       if(nav.classList.contains('open')){
@@ -675,7 +644,6 @@
         openMenu();
       }
     });
-    closeBtn?.addEventListener('click',closeMenu);
     overlay?.addEventListener('click',closeMenu);
     links.forEach(link=>link.addEventListener('click',closeMenu));
     document.addEventListener('click',e=>{


### PR DESCRIPTION
## Summary
- remove the dedicated close button from the mobile navigation drawer
- tidy up unused styles and script references to the removed button while keeping focus management by targeting the first link

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68cff3465d5483208a81c17ac3be36c2