### PR TITLE
Add safety details card to accommodation description

### DIFF
--- a/index.html
+++ b/index.html
@@ -152,7 +152,7 @@
     .section-sub{color:var(--muted); margin:0 0 24px}
 
     /* Features */
-    .features{display:grid; grid-template-columns: repeat(3, 1fr); gap:16px}
+    .features{display:grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap:16px}
     .feature{background:var(--card); padding:18px; border-radius:16px; box-shadow: var(--shadow)}
     .feature b{display:block; margin-bottom:6px}
 
@@ -400,6 +400,11 @@
         <div class="feature"> 
           <b>Τοποθεσία</b>
           Ήσυχη γειτονιά, κοντά σε στάση μετρό/λεωφορείου. Το σημείο ενδιαφέροντος Στύλοι του Ολυμπίου Διός είναι 2,6 χλμ μακριά από το Hidden Pearl Dafnis Apartment, ενώ το σημείο ενδιαφέροντος Σταθμός Μετρό Ακρόπολις είναι 2,7 χλμ μακριά. Το αεροδρόμιο Αεροδρόμιο Ελευθέριος Βενιζέλος είναι 32 χλμ μακριά από το κατάλυμα
+        </div>
+        <div class="feature">
+          <b>Ασφάλεια</b>
+          Πιστοποιημένοι ανιχνευτές καπνού, πυροσβεστήρας, κιτ πρώτων βοηθειών και σαφείς οδηγίες εκκένωσης για την ασφάλεια
+          κάθε επισκέπτη.
         </div>
       </div>
     </div>


### PR DESCRIPTION
## Summary
- update the description feature grid to use an auto-fitting layout for better wrapping
- add a dedicated "Ασφάλεια" card in the accommodation description section to outline safety amenities

## Testing
- not run (static content change)


------
https://chatgpt.com/codex/tasks/task_e_68cff4af8bf883208518820e31d7eb99