### PR TITLE
Add feature icons to description boxes

### DIFF
--- a/index.html
+++ b/index.html
@@ -153,10 +153,11 @@
 
     /* Features */
     .features{display:grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap:16px}
-    .feature{background:var(--card); padding:18px; border-radius:16px; box-shadow: var(--shadow); transition: transform .3s ease, box-shadow .3s ease}
+    .feature{background:var(--card); padding:18px 18px 18px 18px; padding-right:80px; border-radius:16px; box-shadow: var(--shadow); transition: transform .3s ease, box-shadow .3s ease; position:relative}
     .feature:hover,
     .feature:focus-within{transform:translateY(-6px); box-shadow:0 18px 40px rgba(0,0,0,.12)}
     .feature b{display:block; margin-bottom:6px}
+    .feature .feature-icon{position:absolute; top:18px; right:18px; width:48px; height:48px; object-fit:contain; pointer-events:none}
 
     /* Gallery - Carousel */
     .gallery-carousel{position:relative}
@@ -392,18 +393,22 @@
       <p class="section-sub">Ένας προσεγμένος χώρος με όλες τις σύγχρονες ανέσεις για χαλαρή διαμονή.</p>
       <div class="features">
         <div class="feature">
+          <img src="SVG/apartment.svg" class="feature-icon" alt="" aria-hidden="true" />
           <b>Το Διαμέρισμα</b>
           Το Hidden Pearl Dafnis βρίσκεται στην Αθήνα στην περιοχή της Δάφνης, σε απόσταση 250 μετρων από το σημείο ενδιαφέροντος Σταθμός Μετρό Δάφνης κ αντίστοιχα 350 μέτρων από τον σταθμό του Αγίου Ιωάννη. Παρέχει κ προσφέρει στους επισκέπτες κλιματιζόμενους χώρους με δωρεάν WiFi, πλήρης εξοπλισμένη κουζίνα κ μπάνιο με προϊόντα περιποίησης, smart tv , king size κρεβάτι με στρώμα αφρού μνήμης ή δύο μονά και έναν καναπέ κρεβάτι που μπορεί να φιλοξενήσει άνετα δύο παιδιά
         </div>
         <div class="feature">
+          <img src="SVG/amenities.svg" class="feature-icon" alt="" aria-hidden="true" />
           <b>Παροχές</b>
           40 m², Wi‑Fi, A/C, Smart TV, Led κρυφός φωτισμός φούρνος μικροκυμάτων, επαγωγικές εστίες, ψυγείο, καφετιέρα, βραστήρας, προϊόντα περιποίησης, πλυντήριο ρούχων, στεγνωτήριο ρούχων
         </div>
-        <div class="feature"> 
+        <div class="feature">
+          <img src="SVG/location.svg" class="feature-icon" alt="" aria-hidden="true" />
           <b>Τοποθεσία</b>
           Ήσυχη γειτονιά, κοντά σε στάση μετρό/λεωφορείου. Το σημείο ενδιαφέροντος Στύλοι του Ολυμπίου Διός είναι 2,6 χλμ μακριά από το Hidden Pearl Dafnis Apartment, ενώ το σημείο ενδιαφέροντος Σταθμός Μετρό Ακρόπολις είναι 2,7 χλμ μακριά. Το αεροδρόμιο Αεροδρόμιο Ελευθέριος Βενιζέλος είναι 32 χλμ μακριά από το κατάλυμα
         </div>
         <div class="feature">
+          <img src="SVG/safety.svg" class="feature-icon" alt="" aria-hidden="true" />
           <b>Ασφάλεια</b>
           Σύστημα συναγερμού, εξωτερική κάμερα ασφαλείας, πιστοποιημένοι ανιχνευτές καπνού και μονοξειδίου του άνθρακα,
           πόρτα ασφαλείας με ηλεκτρονική κλειδαριά που κλειδώνει αυτόματα, πυροσβεστήρας, κιτ πρώτων βοηθειών και σαφείς


### PR DESCRIPTION
## Summary
- add decorative SVG icons to each feature card in the description section
- update feature card styling to position icons in the top-right corner

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d00a9a54688320be08153c32fa4455