### PR TITLE
Add general information details to accommodation section

### DIFF
--- a/index.html
+++ b/index.html
@@ -190,6 +190,10 @@
     .feature:focus-within{transform:translateY(-6px); box-shadow:0 18px 40px rgba(0,0,0,.12)}
     .feature b{display:block; margin-bottom:6px}
     .feature .feature-icon{position:absolute; top:18px; right:18px; width:48px; height:48px; object-fit:contain; pointer-events:none}
+    .general-info{margin-top:24px; background:var(--card); padding:20px; border-radius:16px; box-shadow:var(--shadow); line-height:1.6}
+    .general-info h3{margin:0 0 12px; font-size:20px}
+    .general-info p{margin:0 0 12px; color:var(--muted)}
+    .general-info p:last-child{margin-bottom:0}
 
     /* Gallery - Carousel */
     .gallery-carousel{position:relative}
@@ -450,6 +454,20 @@
           πόρτα ασφαλείας με ηλεκτρονική κλειδαριά που κλειδώνει αυτόματα, πυροσβεστήρας, κιτ πρώτων βοηθειών και σαφείς
           οδηγίες εκκένωσης για την ασφάλεια κάθε επισκέπτη.
         </div>
+      </div>
+      <div class="general-info">
+        <h3>Γενικές πληροφορίες</h3>
+        <p>
+          Ο χρόνος της διαδρομής με τα πόδια και με το αυτοκίνητο βασίζεται στην πιο γρήγορη διαδρομή από το κατάλυμα. Όταν δεν
+          υπάρχει διαθέσιμη διαδρομή, οι αποστάσεις υπολογίζονται σε ευθεία γραμμή. Ο πραγματικός χρόνος διαδρομής και οι αποστάσεις
+          ενδέχεται να διαφέρουν.
+        </p>
+        <p>
+          Παρακαλείστε να ενημερώσετε το Hidden Pearl Dafnis Boutique Apartment εκ των προτέρων σχετικά με την αναμενόμενη ώρα
+          άφιξής σας. Μπορείτε για την κράτησή σας να επικοινωνήσετε απευθείας με το κατάλυμα μέσω email, στα στοιχεία επικοινωνίας
+          που αναγράφονται στη σελίδα μας.
+        </p>
+        <p>Αυτό το κατάλυμα δεν φιλοξενεί μπάτσελορ ή αντίστοιχα πάρτι κ συγκεντρώσεις ατόμων.</p>
       </div>
     </div>
   </section>


### PR DESCRIPTION
## Summary
- add a "Γενικές πληροφορίες" block beneath the accommodation feature cards
- include messaging about travel times, arrival coordination, and event restrictions
- style the new block so it visually matches the existing cards

## Testing
- not run (static files)


------
https://chatgpt.com/codex/tasks/task_e_68d0182fb8148320a94e549de528395e