### PR TITLE
Adjust hero popup position and add speech bubble tail

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,6 +127,50 @@
       background:url("images/hiddenpearl1.jpg") center/cover no-repeat;
       color:#fff;
     }
+    .hero-popup{
+      position:absolute;
+      top: clamp(120px, 22vh, 240px);
+      left: clamp(16px, 5vw, 64px);
+      max-width:min(360px, calc(100% - 32px));
+      padding:18px 44px 18px 18px;
+      background:#ffffff;
+      color:var(--text);
+      border-radius:14px;
+      box-shadow:0 12px 28px rgba(15,23,42,.18);
+      line-height:1.6;
+      font-size:14px;
+      opacity:0;
+      transform:translateY(-12px);
+      transition:opacity .4s ease, transform .4s ease;
+      z-index:2;
+    }
+    .hero-popup::after{
+      content:"";
+      position:absolute;
+      bottom:-14px;
+      left:40px;
+      width:0;
+      height:0;
+      border-width:14px 12px 0 12px;
+      border-style:solid;
+      border-color:#ffffff transparent transparent transparent;
+      filter: drop-shadow(0 6px 8px rgba(15,23,42,.18));
+    }
+    .hero-popup.show{opacity:1; transform:translateY(0);}
+    .hero-popup.hide{opacity:0; transform:translateY(-12px); pointer-events:none;}
+    .hero-popup button{
+      position:absolute;
+      top:8px;
+      right:8px;
+      border:0;
+      background:transparent;
+      color:var(--muted);
+      font-size:18px;
+      line-height:1;
+      cursor:pointer;
+      padding:4px;
+    }
+    .hero-popup button:focus{outline:none; box-shadow:0 0 0 3px var(--ring); border-radius:8px;}
     .hero::before{
       content:"";
       position:absolute;
@@ -376,6 +420,10 @@
 
   <!-- HERO -->
   <main id="home" class="hero">
+    <aside class="hero-popup" role="status" aria-live="polite">
+      Παρακαλώ για τις κρατήσεις σας ενημερώστε μας με email αναλυτικά για τις ημερομηνίες άφιξης και αναχώρησης για να ενημερώσουμε για την διαθεσιμότητα
+      <button type="button" class="hero-popup-close" aria-label="Κλείσιμο ειδοποίησης">&times;</button>
+    </aside>
     <div class="hero-content container">
       <h1>Ένα «κρυφό μαργαριτάρι» στην Αθήνα</h1>
       <p>Μοντέρνο, φωτεινό διαμέρισμα με προσεγμένο design, ιδανικό για ζευγάρια ή solo ταξιδιώτες. Μερικά βήματα από συγκοινωνίες, καφέ και αγορές.</p>
@@ -668,6 +716,24 @@
     window.addEventListener('resize',()=>{
       if(window.innerWidth>=768) closeMenu();
     });
+  })();
+  (function(){
+    const popup=document.querySelector('.hero-popup');
+    const closeBtn=popup?.querySelector('.hero-popup-close');
+    if(!popup||!closeBtn) return;
+    function hidePopup(){
+      popup.classList.remove('show');
+      popup.classList.add('hide');
+    }
+    closeBtn.addEventListener('click',()=>{
+      hidePopup();
+      popup.addEventListener('transitionend',()=>{popup.style.display='none';},{once:true});
+    });
+    setTimeout(()=>{
+      if(!popup.classList.contains('hide')){
+        popup.classList.add('show');
+      }
+    },1000);
   })();
 </script>
 </html>


### PR DESCRIPTION
## Summary
- add a styled popup notice to the hero section with reservation details in Greek
- implement fade-in animation and dismissible close button behaviour with vanilla JS
- position the popup lower in the hero and add a speech-bubble tail for better visibility

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d0161217dc83208368b5d729b7c331