### PR TITLE
Update contact widget icons

### DIFF
--- a/SVG/email.svg
+++ b/SVG/email.svg
@@ -8,7 +8,7 @@
 
 </defs>
     <g id="Page-1" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd">
-        <g id="Dribbble-Light-Preview" transform="translate(-300.000000, -922.000000)" fill="#000000">
+        <g id="Dribbble-Light-Preview" transform="translate(-300.000000, -922.000000)" fill="#43D9D7">
             <g id="icons" transform="translate(56.000000, 160.000000)">
                 <path d="M262,764.291 L254,771.318 L246,764.281 L246,764 L262,764 L262,764.291 Z M246,775 L246,766.945 L254,773.98 L262,766.953 L262,775 L246,775 Z M244,777 L264,777 L264,762 L244,762 L244,777 Z" id="email-[#1573]">
 

--- a/index.html
+++ b/index.html
@@ -300,9 +300,12 @@
     }
     .contact-widget__link{
       display:flex;
+      flex-direction:column;
       align-items:center;
-      gap:10px;
-      padding:10px;
+      justify-content:center;
+      text-align:center;
+      gap:8px;
+      padding:12px;
       border-radius:12px;
       font-weight:600;
       color:inherit;
@@ -317,8 +320,16 @@
       box-shadow:0 0 0 3px var(--ring);
     }
     .contact-widget__icon{
-      font-size:18px;
+      display:inline-flex;
+      align-items:center;
+      justify-content:center;
+      width:36px;
+      height:36px;
       line-height:1;
+    }
+    .contact-widget__icon img{
+      width:100%;
+      height:100%;
     }
     @media (max-width: 767px) {
       .nav > .social{display:none}
@@ -652,11 +663,15 @@
   <div class="contact-widget" aria-label="Γρήγορη επικοινωνία">
     <div id="contactWidgetPanel" class="contact-widget__panel" aria-hidden="true">
       <a class="contact-widget__link" href="mailto:hiddenpearldafnis@gmail.com">
-        <span class="contact-widget__icon" aria-hidden="true">📧</span>
+        <span class="contact-widget__icon" aria-hidden="true">
+          <img src="SVG/email.svg" width="36" height="36" alt="" loading="lazy" />
+        </span>
         <span>Email</span>
       </a>
       <a class="contact-widget__link" href="viber://chat?number=+306979299999">
-        <span class="contact-widget__icon" aria-hidden="true">📞</span>
+        <span class="contact-widget__icon" aria-hidden="true">
+          <img src="SVG/viber.svg" width="36" height="36" alt="" loading="lazy" />
+        </span>
         <span>Viber</span>
       </a>
     </div>


### PR DESCRIPTION
## Summary
- use the branded email icon and the Viber SVG from the SVG directory in the contact widget
- update the email SVG fill to match the site header color
- restyle the contact widget links so the icons and labels stack vertically

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d0319f8b148320bc30ecc474d12495