### PR TITLE
Adjust contact widget sizing

### DIFF
--- a/index.html
+++ b/index.html
@@ -279,13 +279,13 @@
     .contact-widget__panel{
       background:#fff;
       color:var(--text);
-      border-radius:16px;
-      padding:14px 18px;
-      min-width:220px;
+      border-radius:14px;
+      padding:10px 14px;
+      min-width:190px;
       box-shadow:0 16px 32px rgba(15,23,42,.18);
       display:flex;
       flex-direction:column;
-      gap:10px;
+      gap:6px;
       opacity:0;
       transform:translateY(10px) scale(.98);
       visibility:hidden;
@@ -300,13 +300,13 @@
     }
     .contact-widget__link{
       display:flex;
-      flex-direction:column;
+      flex-direction:row;
       align-items:center;
-      justify-content:center;
-      text-align:center;
-      gap:8px;
-      padding:12px;
-      border-radius:12px;
+      justify-content:flex-start;
+      text-align:left;
+      gap:10px;
+      padding:8px 10px;
+      border-radius:10px;
       font-weight:600;
       color:inherit;
       transition:background .2s ease, transform .2s ease;
@@ -323,8 +323,8 @@
       display:inline-flex;
       align-items:center;
       justify-content:center;
-      width:36px;
-      height:36px;
+      width:32px;
+      height:32px;
       line-height:1;
     }
     .contact-widget__icon img{


### PR DESCRIPTION
## Summary
- shrink the contact widget panel padding and width to reduce its footprint
- update link layout to align icons beside labels for a more compact appearance
- resize contact icons to match the tightened layout

## Testing
- no automated tests were run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68d03339ff38832096dc80aa2782ee15