### PR TITLE
Fix hero popup layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -129,27 +129,49 @@
     }
     .hero-popup{
       position:absolute;
-
+      left: clamp(16px, 4vw, 40px);
+      bottom: clamp(16px, 4vw, 40px);
+      max-width:320px;
+      padding:18px 20px 18px 20px;
+      border-radius:16px;
+      background:rgba(255,255,255,.92);
+      color:var(--text);
+      box-shadow:var(--shadow);
       opacity:0;
       transform:translateY(-12px);
       transition:opacity .4s ease, transform .4s ease;
       z-index:2;
+      backdrop-filter: blur(6px);
     }
 
     .hero-popup.show{opacity:1; transform:translateY(0);}
     .hero-popup.hide{opacity:0; transform:translateY(-12px); pointer-events:none;}
     .hero-popup button{
       position:absolute;
-
+      top:10px;
+      right:10px;
       border:0;
       background:transparent;
       color:var(--muted);
-      font-size:18px;
+      font-size:20px;
       line-height:1;
       cursor:pointer;
       padding:4px;
     }
     .hero-popup button:focus{outline:none; box-shadow:0 0 0 3px var(--ring); border-radius:8px;}
+    .hero-popup__content{padding-right:24px;}
+    .hero-popup__title{margin:0 0 6px 0; font-size:18px; font-weight:700;}
+    .hero-popup__text{margin:0 0 12px 0; color:var(--muted); line-height:1.5;}
+    .hero-popup__cta{display:inline-flex; align-items:center; gap:6px; font-weight:600; color:var(--btn);}
+    .hero-popup__cta svg{width:16px; height:16px;}
+    @media (max-width: 640px){
+      .hero-popup{
+        right:16px;
+        left:16px;
+        bottom:16px;
+        max-width:none;
+      }
+    }
     .hero::before{
       content:"";
       position:absolute;
@@ -493,7 +515,14 @@
   <!-- HERO -->
   <main id="home" class="hero">
     <aside class="hero-popup" role="status" aria-live="polite">
-
+      <div class="hero-popup__content">
+        <p class="hero-popup__title">Κλείσε απευθείας &amp; κέρδισε!</p>
+        <p class="hero-popup__text">Κάνε την κράτησή σου μέσα από την επίσημη φόρμα μας και απόλαυσε δωρεάν early check-in, βάσει διαθεσιμότητας.</p>
+        <a class="hero-popup__cta" href="https://hiddenpearldafnis.setmore.com" target="_blank" rel="noopener">
+          Κλείσε τώρα
+          <svg viewBox="0 0 20 20" fill="none" aria-hidden="true"><path d="M4 10h12M11 5l5 5-5 5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
+        </a>
+      </div>
       <button type="button" class="hero-popup-close" aria-label="Κλείσιμο ειδοποίησης">&times;</button>
     </aside>
     <div class="hero-content container">


### PR DESCRIPTION
## Summary
- style the hero popup so it is anchored to the bottom-left of the hero background with proper padding and contrast
- add structured content and call-to-action within the popup to ensure it appears when the animation runs

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d034514504832088dd6237e15a8d09