### PR TITLE
Add info icon to general info section

### DIFF
--- a/SVG/info.svg
+++ b/SVG/info.svg
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?><!-- Uploaded to: SVG Repo, www.svgrepo.com, Generator: SVG Repo Mixer Tools -->
 <svg width="800px" height="800px" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg" fill="none">
-  <path fill="#000000" fill-rule="evenodd" d="M10 3a7 7 0 100 14 7 7 0 000-14zm-9 7a9 9 0 1118 0 9 9 0 01-18 0zm8-4a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1zm.01 8a1 1 0 102 0V9a1 1 0 10-2 0v5z"/>
+  <path fill="#43D9D7" fill-rule="evenodd" d="M10 3a7 7 0 100 14 7 7 0 000-14zm-9 7a9 9 0 1118 0 9 9 0 01-18 0zm8-4a1 1 0 011-1h.01a1 1 0 110 2H10a1 1 0 01-1-1zm.01 8a1 1 0 102 0V9a1 1 0 10-2 0v5z"/>
 </svg>

--- a/index.html
+++ b/index.html
@@ -204,6 +204,7 @@
     .feature b{display:block; margin-bottom:6px}
     .feature .feature-icon{position:absolute; top:18px; right:18px; width:48px; height:48px; object-fit:contain; pointer-events:none}
     .general-info{margin-top:24px; background:var(--card); padding:20px; border-radius:16px; box-shadow:var(--shadow); line-height:1.6; transition: transform .3s ease, box-shadow .3s ease}
+    .general-info__icon{display:block; width:40px; height:40px; margin:0 0 12px;}
     .general-info h3{margin:0 0 12px; font-size:20px}
     .general-info p{margin:0 0 12px; color:var(--muted)}
     .general-info p:last-child{margin-bottom:0}
@@ -565,6 +566,7 @@
         </div>
       </div>
       <div class="general-info">
+        <img src="SVG/info.svg" class="general-info__icon" alt="" aria-hidden="true" />
         <h3>Γενικές πληροφορίες</h3>
         <p>
           Ο χρόνος της διαδρομής με τα πόδια και με το αυτοκίνητο βασίζεται στην πιο γρήγορη διαδρομή από το κατάλυμα. Όταν δεν


### PR DESCRIPTION
## Summary
- add the info graphic to the Γενικές πληροφορίες callout below the Περιγραφή Καταλύματος feature cards
- tint the info.svg asset to use the brand header color so the icon matches the design

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d035c2fd748320bfd669291c1fa1c6