### PR TITLE
Update hero popup booking message and styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -135,7 +135,7 @@
       padding:18px 20px 18px 20px;
       border-radius:16px;
       background:rgba(255,255,255,.92);
-      color:var(--text);
+      color:#000000;
       box-shadow:var(--shadow);
       opacity:0;
       transform:translateY(-12px);
@@ -161,7 +161,7 @@
     .hero-popup button:focus{outline:none; box-shadow:0 0 0 3px var(--ring); border-radius:8px;}
     .hero-popup__content{padding-right:24px;}
     .hero-popup__title{margin:0 0 6px 0; font-size:18px; font-weight:700;}
-    .hero-popup__text{margin:0 0 12px 0; color:var(--muted); line-height:1.5;}
+    .hero-popup__text{margin:0 0 12px 0; color:#000000; line-height:1.5;}
     .hero-popup__cta{display:inline-flex; align-items:center; gap:6px; font-weight:600; color:var(--btn);}
     .hero-popup__cta svg{width:16px; height:16px;}
     @media (max-width: 640px){
@@ -516,9 +516,9 @@
   <main id="home" class="hero">
     <aside class="hero-popup" role="status" aria-live="polite">
       <div class="hero-popup__content">
-        <p class="hero-popup__title">Κλείσε απευθείας &amp; κέρδισε!</p>
-        <p class="hero-popup__text">Κάνε την κράτησή σου μέσα από την επίσημη φόρμα μας και απόλαυσε δωρεάν early check-in, βάσει διαθεσιμότητας.</p>
-        <a class="hero-popup__cta" href="https://hiddenpearldafnis.setmore.com" target="_blank" rel="noopener">
+        <p class="hero-popup__title">Για κρατήσεις</p>
+        <p class="hero-popup__text">Για κρατήσεις, παρακαλούμε στείλτε μας email με τις επιθυμητές ημερομηνίες άφιξης και αναχώρησης ώστε να σας ενημερώσουμε άμεσα για τη διαθεσιμότητα.</p>
+        <a class="hero-popup__cta" href="mailto:hiddenpearldafnis@gmail.com">
           Κλείσε τώρα
           <svg viewBox="0 0 20 20" fill="none" aria-hidden="true"><path d="M4 10h12M11 5l5 5-5 5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
         </a>


### PR DESCRIPTION
## Summary
- update the hero popup copy to direct guests to email for availability
- point the popup call-to-action button to the property email address instead of Setmore
- ensure the popup text renders in black for better contrast with the new message

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d0371e39ac8320a80324d805a6c867