### PR TITLE
Ensure hero popup text uses black coloring

### DIFF
--- a/index.html
+++ b/index.html
@@ -162,7 +162,17 @@
     .hero-popup__content{padding-right:24px;}
     .hero-popup__title{margin:0 0 6px 0; font-size:18px; font-weight:700;}
     .hero-popup__text{margin:0 0 12px 0; color:#000000; line-height:1.5;}
-    .hero-popup__cta{display:inline-flex; align-items:center; gap:6px; font-weight:600; color:var(--btn);}
+    .hero-popup__cta{
+      display:inline-flex;
+      align-items:center;
+      gap:6px;
+      font-weight:600;
+      color:#000000;
+    }
+    .hero-popup__cta:hover,
+    .hero-popup__cta:focus{
+      color:#000000;
+    }
     .hero-popup__cta svg{width:16px; height:16px;}
     @media (max-width: 640px){
       .hero-popup{


### PR DESCRIPTION
## Summary
- restyle the hero popup call-to-action to inherit a consistent black text color
- ensure hover and focus states keep the popup lettering black for readability

## Testing
- no automated tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d03a18e894832097971cfcb870ae2f