### PR TITLE
Reposition general info icon

### DIFF
--- a/index.html
+++ b/index.html
@@ -214,9 +214,9 @@
     .feature:focus-within{transform:translateY(-6px); box-shadow:0 18px 40px rgba(0,0,0,.12)}
     .feature b{display:block; margin-bottom:6px}
     .feature .feature-icon{position:absolute; top:18px; right:18px; width:48px; height:48px; object-fit:contain; pointer-events:none}
-    .general-info{margin-top:24px; background:var(--card); padding:20px; border-radius:16px; box-shadow:var(--shadow); line-height:1.6; transition: transform .3s ease, box-shadow .3s ease}
-    .general-info__icon{display:block; width:40px; height:40px; margin:0 0 12px;}
-    .general-info h3{margin:0 0 12px; font-size:20px}
+    .general-info{margin-top:24px; background:var(--card); padding:20px; border-radius:16px; box-shadow:var(--shadow); line-height:1.6; transition: transform .3s ease, box-shadow .3s ease; position:relative; padding-right:72px}
+    .general-info__icon{display:block; width:40px; height:40px; margin:0; position:absolute; top:20px; right:20px}
+    .general-info h3{margin:0 0 12px; font-size:20px; padding-right:48px}
     .general-info p{margin:0 0 12px; color:var(--muted)}
     .general-info p:last-child{margin-bottom:0}
     .general-info:hover,


### PR DESCRIPTION
## Summary
- position the general info card relative and move the info icon to the top-right
- adjust heading padding so text and icon do not overlap

## Testing
- no tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d03cab5a4083209a5171d2c24dbb97