### PR TITLE
Split hero title onto two lines

### DIFF
--- a/index.html
+++ b/index.html
@@ -197,6 +197,7 @@
       margin-top: clamp(72px, 9vw, 112px);
     }
     .hero h1{font-size: clamp(28px, 4.4vw, 48px); margin:0 0 12px 0; text-shadow:0 1px 4px rgba(0,0,0,.4)}
+    .hero h1 span{display:block}
     .hero p{font-size: clamp(16px, 1.4vw, 18px); margin:0 0 16px 0; color:rgba(255,255,255,.9); text-shadow:0 1px 4px rgba(0,0,0,.4)}
     .cta{display:inline-flex; align-items:center; gap:10px; padding:14px 18px; background:var(--brand); color:var(--brand-text); border-radius:12px; box-shadow: var(--shadow); font-weight:700; outline:1px solid transparent; transition: background .2s, color .2s; position:relative; z-index:1}
     .cta:hover{background:var(--bg); color:var(--brand)}
@@ -539,7 +540,7 @@
       <button type="button" class="hero-popup-close" aria-label="Κλείσιμο ειδοποίησης">&times;</button>
     </aside>
     <div class="hero-content container">
-      <h1>Ένα «κρυφό μαργαριτάρι» στην Αθήνα</h1>
+      <h1>Ένα «κρυφό μαργαριτάρι» <span>στην Αθήνα</span></h1>
       <p>Μοντέρνο, φωτεινό διαμέρισμα με προσεγμένο design, ιδανικό για ζευγάρια ή solo ταξιδιώτες. Μερικά βήματα από συγκοινωνίες, καφέ και αγορές.</p>
       <a id="ctaBooking" class="cta" href="https://hiddenpearldafnis.setmore.com" target="_blank" rel="noopener">
         Κλείσε Διαμονή


### PR DESCRIPTION
## Summary
- split the hero heading into two lines by wrapping the second phrase in a span
- ensure the new span renders on its own line via CSS

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d03d7363988320831b1569b1482c49