### PR TITLE
Adjust feature titles spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -212,7 +212,7 @@
     .feature{background:var(--card); padding:18px 18px 18px 18px; padding-right:80px; border-radius:16px; box-shadow: var(--shadow); transition: transform .3s ease, box-shadow .3s ease; position:relative}
     .feature:hover,
     .feature:focus-within{transform:translateY(-6px); box-shadow:0 18px 40px rgba(0,0,0,.12)}
-    .feature b{display:block; margin-bottom:6px}
+    .feature b{display:block; margin:0 0 2em}
     .feature .feature-icon{position:absolute; top:18px; right:18px; width:48px; height:48px; object-fit:contain; pointer-events:none}
     .general-info{margin-top:24px; background:var(--card); padding:20px; border-radius:16px; box-shadow:var(--shadow); line-height:1.6; transition: transform .3s ease, box-shadow .3s ease; position:relative; padding-right:72px}
     .general-info__icon{display:block; width:40px; height:40px; margin:0; position:absolute; top:20px; right:20px}


### PR DESCRIPTION
## Summary
- add extra vertical space beneath each feature box heading in the accommodation description section

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d03ddf12b08320b243162bf11214d5