### PR TITLE
Adjust accommodation description layout

### DIFF
--- a/index.html
+++ b/index.html
@@ -210,11 +210,18 @@
 
     /* Features */
     .features{display:grid; grid-template-columns: repeat(auto-fit, minmax(220px, 1fr)); gap:16px}
-    .feature{background:var(--card); padding:18px 18px 18px 18px; padding-right:80px; border-radius:16px; box-shadow: var(--shadow); transition: transform .3s ease, box-shadow .3s ease; position:relative}
+    .feature{background:var(--card); padding:18px; border-radius:16px; box-shadow: var(--shadow); transition: transform .3s ease, box-shadow .3s ease; position:relative; display:grid; grid-template-columns: minmax(0,1fr) auto; column-gap:16px; align-items:flex-start}
     .feature:hover,
     .feature:focus-within{transform:translateY(-6px); box-shadow:0 18px 40px rgba(0,0,0,.12)}
-    .feature b{display:block; margin:0 0 2em}
-    .feature .feature-icon{position:absolute; top:18px; right:18px; width:48px; height:48px; object-fit:contain; pointer-events:none}
+    .feature b{display:block; margin:0 0 8px; grid-column:1}
+    .feature p{grid-column:1; margin:0; color:var(--muted); line-height:1.6}
+    .feature .feature-icon{grid-column:2; grid-row:1 / span 2; width:48px; height:48px; object-fit:contain; pointer-events:none; position:static}
+    @media (max-width: 600px){
+      .feature{grid-template-columns: minmax(0,1fr);}
+      .feature .feature-icon{grid-column:1; grid-row:1; justify-self:flex-end; margin-bottom:12px}
+      .feature b{grid-row:2}
+      .feature p{grid-row:3}
+    }
     .general-info{margin-top:24px; background:var(--card); padding:20px; border-radius:16px; box-shadow:var(--shadow); line-height:1.6; transition: transform .3s ease, box-shadow .3s ease; position:relative; padding-right:72px}
     .general-info__icon{display:block; width:40px; height:40px; margin:0; position:absolute; top:20px; right:20px}
     .general-info h3{margin:0 0 12px; font-size:20px; padding-right:48px}
@@ -558,24 +565,22 @@
         <div class="feature">
           <img src="SVG/apartment.svg" class="feature-icon" alt="" aria-hidden="true" />
           <b>Το Διαμέρισμα</b>
-          Το Hidden Pearl Dafnis βρίσκεται στην Αθήνα στην περιοχή της Δάφνης, σε απόσταση 250 μετρων από το σημείο ενδιαφέροντος Σταθμός Μετρό Δάφνης κ αντίστοιχα 350 μέτρων από τον σταθμό του Αγίου Ιωάννη. Παρέχει κ προσφέρει στους επισκέπτες κλιματιζόμενους χώρους με δωρεάν WiFi, πλήρης εξοπλισμένη κουζίνα κ μπάνιο με προϊόντα περιποίησης, smart tv , king size κρεβάτι με στρώμα αφρού μνήμης ή δύο μονά και έναν καναπέ κρεβάτι που μπορεί να φιλοξενήσει άνετα δύο παιδιά.
+          <p>Το Hidden Pearl Dafnis βρίσκεται στην Αθήνα στην περιοχή της Δάφνης, σε απόσταση 250 μετρων από το σημείο ενδιαφέροντος Σταθμός Μετρό Δάφνης κ αντίστοιχα 350 μέτρων από τον σταθμό του Αγίου Ιωάννη. Παρέχει κ προσφέρει στους επισκέπτες κλιματιζόμενους χώρους με δωρεάν WiFi, πλήρης εξοπλισμένη κουζίνα κ μπάνιο με προϊόντα περιποίησης, smart tv , king size κρεβάτι με στρώμα αφρού μνήμης ή δύο μονά και έναν καναπέ κρεβάτι που μπορεί να φιλοξενήσει άνετα δύο παιδιά.</p>
         </div>
         <div class="feature">
           <img src="SVG/amenities.svg" class="feature-icon" alt="" aria-hidden="true" />
           <b>Παροχές</b>
-          40 m², Wi‑Fi, A/C, Smart TV, Led κρυφός φωτισμός φούρνος μικροκυμάτων, επαγωγικές εστίες, ψυγείο, καφετιέρα, βραστήρας, προϊόντα περιποίησης, πλυντήριο ρούχων, στεγνωτήριο ρούχων, πιστολάκι μαλλιών, σίδερο μαλλιών, σετ σιδερώματος ρούχων.
+          <p>40 m², Wi‑Fi, A/C, Smart TV, Led κρυφός φωτισμός φούρνος μικροκυμάτων, επαγωγικές εστίες, ψυγείο, καφετιέρα, βραστήρας, προϊόντα περιποίησης, πλυντήριο ρούχων, στεγνωτήριο ρούχων, πιστολάκι μαλλιών, σίδερο μαλλιών, σετ σιδερώματος ρούχων.</p>
         </div>
         <div class="feature">
           <img src="SVG/location.svg" class="feature-icon" alt="" aria-hidden="true" />
           <b>Τοποθεσία</b>
-          Ήσυχη γειτονιά, κοντά σε στάση μετρό/λεωφορείου. Το σημείο ενδιαφέροντος Στύλοι του Ολυμπίου Διός είναι 2,6 χλμ μακριά από το Hidden Pearl Dafnis Apartment, ενώ το σημείο ενδιαφέροντος Σταθμός Μετρό Ακρόπολις είναι 2,7 χλμ μακριά. Το αεροδρόμιο Αεροδρόμιο Ελευθέριος Βενιζέλος είναι 32 χλμ μακριά από το κατάλυμα.
+          <p>Ήσυχη γειτονιά, κοντά σε στάση μετρό/λεωφορείου. Το σημείο ενδιαφέροντος Στύλοι του Ολυμπίου Διός είναι 2,6 χλμ μακριά από το Hidden Pearl Dafnis Apartment, ενώ το σημείο ενδιαφέροντος Σταθμός Μετρό Ακρόπολις είναι 2,7 χλμ μακριά. Το αεροδρόμιο Αεροδρόμιο Ελευθέριος Βενιζέλος είναι 32 χλμ μακριά από το κατάλυμα.</p>
         </div>
         <div class="feature">
           <img src="SVG/safety.svg" class="feature-icon" alt="" aria-hidden="true" />
           <b>Ασφάλεια</b>
-          Σύστημα συναγερμού, εξωτερική κάμερα ασφαλείας, πιστοποιημένοι ανιχνευτές καπνού και μονοξειδίου του άνθρακα,
-          πόρτα ασφαλείας με ηλεκτρονική κλειδαριά που κλειδώνει αυτόματα, πυροσβεστήρας, κιτ πρώτων βοηθειών και σαφείς
-          οδηγίες εκκένωσης για την ασφάλεια κάθε επισκέπτη.
+          <p>Σύστημα συναγερμού, εξωτερική κάμερα ασφαλείας, πιστοποιημένοι ανιχνευτές καπνού και μονοξειδίου του άνθρακα, πόρτα ασφαλείας με ηλεκτρονική κλειδαριά που κλειδώνει αυτόματα, πυροσβεστήρας, κιτ πρώτων βοηθειών και σαφείς οδηγίες εκκένωσης για την ασφάλεια κάθε επισκέπτη.</p>
         </div>
       </div>
       <div class="general-info">


### PR DESCRIPTION
## Summary
- update the accommodation description feature cards to use a grid layout so the text fills the available width without an empty gap on the right
- wrap the description copy in paragraph elements for improved semantics and alignment control
- add responsive tweaks so the icon stacks above the text on very small screens

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d03fbca9e883208f62da159f106eae