### PR TITLE
Ensure hero popup text displays in black

### DIFF
--- a/index.html
+++ b/index.html
@@ -161,7 +161,7 @@
     .hero-popup button:focus{outline:none; box-shadow:0 0 0 3px var(--ring); border-radius:8px;}
     .hero-popup__icon{display:block; width:44px; height:44px; margin:0 0 12px 0; object-fit:contain;}
     .hero-popup__content{padding-right:24px;}
-    .hero-popup__title{margin:0 0 6px 0; font-size:18px; font-weight:700;}
+    .hero-popup__title{margin:0 0 6px 0; font-size:18px; font-weight:700; color:#000000;}
     .hero-popup__text{margin:0 0 12px 0; color:#000000; line-height:1.5;}
     .hero-popup__cta{
       display:inline-flex;


### PR DESCRIPTION
## Summary
- set the hero popup title text color explicitly to black so the notification copy renders as intended

## Testing
- no automated tests were run (static site)

------
https://chatgpt.com/codex/tasks/task_e_68d0413432d083209e1fb098effb25cd