### PR TITLE
Scope hero paragraph styling to keep popup text black

### DIFF
--- a/index.html
+++ b/index.html
@@ -198,7 +198,7 @@
     }
     .hero h1{font-size: clamp(28px, 4.4vw, 48px); margin:0 0 12px 0; text-shadow:0 6px 18px rgba(0,0,0,.65), 0 0 24px rgba(0,0,0,.45)}
     .hero h1 span{display:block; font-size:0.8em; color:#6b7280}
-    .hero p{font-size: clamp(16px, 1.4vw, 18px); margin:0 0 16px 0; color:rgba(255,255,255,.9); text-shadow:0 1px 4px rgba(0,0,0,.4)}
+    .hero-content p{font-size: clamp(16px, 1.4vw, 18px); margin:0 0 16px 0; color:rgba(255,255,255,.9); text-shadow:0 1px 4px rgba(0,0,0,.4)}
     .cta{display:inline-flex; align-items:center; gap:10px; padding:14px 18px; background:var(--brand); color:var(--brand-text); border-radius:12px; box-shadow: var(--shadow); font-weight:700; outline:1px solid transparent; transition: background .2s, color .2s; position:relative; z-index:1}
     .cta:hover{background:var(--bg); color:var(--brand)}
     .cta:focus{outline:0; box-shadow:0 0 0 4px var(--ring)}


### PR DESCRIPTION
## Summary
- scope the hero paragraph styling to `.hero-content` so it no longer affects the popup text

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d04c84778c832094928b08a32889ae