### PR TITLE
Adjust hero title layout for responsive display

### DIFF
--- a/index.html
+++ b/index.html
@@ -196,8 +196,12 @@
       max-width:640px;
       margin-top: clamp(72px, 9vw, 112px);
     }
-    .hero h1{font-size: clamp(28px, 4.4vw, 48px); margin:0 0 12px 0; text-shadow:0 6px 18px rgba(0,0,0,.65), 0 0 24px rgba(0,0,0,.45)}
-    .hero h1 span{display:block; font-size:0.8em; color:#6b7280}
+    .hero h1{font-size: clamp(28px, 4.4vw, 48px); margin:0 0 12px 0; text-shadow:0 6px 18px rgba(0,0,0,.45)}
+    .hero h1 .hero-title-line{display:block}
+    .hero h1 .hero-title-line--secondary{font-size:0.85em; color:#6b7280}
+    @media (min-width: 768px){
+      .hero h1 .hero-title-line{white-space:nowrap}
+    }
     .hero p{font-size: clamp(16px, 1.4vw, 18px); margin:0 0 16px 0; color:rgba(255,255,255,.9); text-shadow:0 1px 4px rgba(0,0,0,.4)}
     .cta{display:inline-flex; align-items:center; gap:10px; padding:14px 18px; background:var(--brand); color:var(--brand-text); border-radius:12px; box-shadow: var(--shadow); font-weight:700; outline:1px solid transparent; transition: background .2s, color .2s; position:relative; z-index:1}
     .cta:hover{background:var(--bg); color:var(--brand)}
@@ -573,8 +577,8 @@
     </aside>
     <div class="hero-content container">
       <h1>
-        Ένα «κρυφό μαργαριτάρι»
-        <span>στην Αθήνα!</span>
+        <span class="hero-title-line hero-title-line--primary">Ένα «κρυφό μαργαριτάρι»</span>
+        <span class="hero-title-line hero-title-line--secondary">στην Αθήνα!</span>
       </h1>
       <p>Μοντέρνο, φωτεινό διαμέρισμα με προσεγμένο design, ιδανικό για ζευγάρια ή solo ταξιδιώτες. Μερικά βήματα από συγκοινωνίες, καφέ και αγορές.</p>
       <a id="ctaBooking" class="cta" href="https://hiddenpearldafnis.setmore.com" target="_blank" rel="noopener">


### PR DESCRIPTION
## Summary
- split the hero heading into two span elements for dedicated desktop and mobile line control
- add responsive styling to keep each line on a single row on desktop while allowing natural wrapping on mobile
- apply a consistent text shadow and scale/color adjustments to the second line for visual hierarchy

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d05086ee0c8320b5bce550d49d3c6b