### PR TITLE
Inline safety feature icon and inherit brand color

### DIFF
--- a/index.html
+++ b/index.html
@@ -218,7 +218,7 @@
     .feature:hover,
     .feature:focus-within{transform:translateY(-6px); box-shadow:0 18px 40px rgba(0,0,0,.12)}
     .feature b{display:block; margin:0 0 2em}
-    .feature .feature-icon{position:absolute; top:18px; right:18px; width:48px; height:48px; object-fit:contain; pointer-events:none}
+    .feature .feature-icon{position:absolute; top:18px; right:18px; width:48px; height:48px; object-fit:contain; pointer-events:none; color: var(--brand);}
     .general-info{margin-top:24px; background:var(--card); padding:20px; border-radius:16px; box-shadow:var(--shadow); line-height:1.6; transition: transform .3s ease, box-shadow .3s ease; position:relative; padding-right:72px}
     .general-info__icon{display:block; width:40px; height:40px; margin:0; position:absolute; top:20px; right:20px}
     .general-info h3{margin:0 0 12px; font-size:20px; padding-right:48px}
@@ -610,7 +610,12 @@
           Ήσυχη γειτονιά, κοντά σε στάση μετρό/λεωφορείου. Το σημείο ενδιαφέροντος Στύλοι του Ολυμπίου Διός είναι 2,6 χλμ μακριά από το Hidden Pearl Dafnis Apartment, ενώ το σημείο ενδιαφέροντος Σταθμός Μετρό Ακρόπολις είναι 2,7 χλμ μακριά. Το αεροδρόμιο Αεροδρόμιο Ελευθέριος Βενιζέλος είναι 32 χλμ μακριά από το κατάλυμα.
         </div>
         <div class="feature">
-          <img src="SVG/safety.svg" class="feature-icon" alt="" aria-hidden="true" />
+          <svg class="feature-icon" viewBox="0 0 24 24" fill="none" aria-hidden="true">
+            <path
+              fill="currentColor"
+              d="M11.2978 2.19533c.3961125-.1485575.8276734-.16712719 1.232648-.05570906l.171752.05570906 7 2.625c.7286533.27321467 1.2276818.94148693 1.2909804 1.70719646L21 6.69299v5.36271c0 3.3087353-1.814372 6.341735-4.7089968 7.9112788l-.266103.1386212-3.3541 1.677c-.3753778.1877333-.8097778.2085926-1.1982716.0571778l-.1433284-.0571778-3.35412-1.677C5.01569824 18.6258412 3.11426678 15.6466349 3.00497789 12.3557015L3 12.0557V6.69299c0-.77811067.45049511-1.48004267 1.14521784-1.80817566l.15253216-.06449434L11.2978 2.19533ZM12 4.06799 5 6.69299v5.36271c0 2.56302 1.39981647 4.9134539 3.63528667 6.1383401l.23421333.12266L12 19.882l3.1305-1.5653c2.29245-1.1461767 3.7686628-3.4493824 3.8645298-5.9966558L19 12.0557V6.69299L12 4.06799Zm3.4329 4.5611c.3906-.39053 1.0237-.39053 1.4142 0 .3605538.36048.3882888.92771503.0832047 1.3200035l-.0832047.0942065-5.2344 5.2345c-.3989143.3926714-1.0279617.4272063-1.4597522.0852797l-.0959478-.0852797-2.40415-2.4042c-.39052-.3905-.39052-1.0237 0-1.4142.36048923-.3604615.92771645-.3881893 1.32001152-.0831834l.09420848.0831834 1.76773 1.7678 4.5981-4.59811Z"
+            ></path>
+          </svg>
           <b>Ασφάλεια</b>
           Σύστημα συναγερμού, εξωτερική κάμερα ασφαλείας, πιστοποιημένοι ανιχνευτές καπνού και μονοξειδίου του άνθρακα,
           πόρτα ασφαλείας με ηλεκτρονική κλειδαριά που κλειδώνει αυτόματα, πυροσβεστήρας, κιτ πρώτων βοηθειών και σαφείς


### PR DESCRIPTION
## Summary
- inline the safety feature icon SVG so it can inherit styles directly
- allow feature icons to pick up the brand color from the header for consistent styling

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d052281b5c832093a361cf9ba778e5