### PR TITLE
Add hero toast notification with timed auto-hide

### DIFF
--- a/index.html
+++ b/index.html
@@ -127,60 +127,76 @@
       background:url("images/hiddenpearl1.jpg") center/cover no-repeat;
       color:#fff;
     }
-    .hero-popup{
+    .hero-toast{
       position:absolute;
-      left: clamp(16px, 4vw, 40px);
-      bottom: clamp(16px, 4vw, 40px);
-      max-width:320px;
-      padding:18px 20px 18px 20px;
-      border-radius:16px;
-      background:rgba(255,255,255,.92);
-      color:#000000;
-      box-shadow:var(--shadow);
+      bottom:20px;
+      left:20px;
+      max-width:min(90vw, 340px);
+      padding:20px 24px;
+      border-radius:50px;
+      background:rgba(255,255,255,.85);
+      color:#0f172a;
+      box-shadow:0 18px 45px rgba(15,23,42,.22);
+      backdrop-filter:blur(8px);
+      display:flex;
+      flex-direction:column;
+      gap:12px;
       opacity:0;
-      transform:translateY(-12px);
-      transition:opacity .4s ease, transform .4s ease;
+      visibility:hidden;
+      transform:translateY(16px);
+      pointer-events:none;
+      transition:opacity .35s ease, transform .35s ease, visibility .35s ease;
       z-index:2;
-      backdrop-filter: blur(6px);
     }
-
-    .hero-popup.show{opacity:1; transform:translateY(0);}
-    .hero-popup.hide{opacity:0; transform:translateY(-12px); pointer-events:none;}
-    .hero-popup button{
-      position:absolute;
-      top:10px;
-      right:10px;
-      border:0;
-      background:transparent;
-      color:var(--muted);
-      font-size:20px;
-      line-height:1;
-      cursor:pointer;
-      padding:4px;
+    .hero-toast.is-visible{
+      opacity:1;
+      visibility:visible;
+      transform:translateY(0);
+      pointer-events:auto;
     }
-    .hero-popup button:focus{outline:none; box-shadow:0 0 0 3px var(--ring); border-radius:8px;}
-    .hero-popup__icon{display:block; width:44px; height:44px; margin:0 0 12px 0; object-fit:contain;}
-    .hero-popup__content{padding-right:24px;}
-    .hero-popup__title{margin:0 0 6px 0; font-size:18px; font-weight:700; color:#000000;}
-    .hero-popup__text{margin:0 0 12px 0; color:#000000; line-height:1.5;}
-    .hero-popup__cta{
+    .hero-toast.is-hiding{
+      opacity:0;
+      transform:translateY(16px);
+      pointer-events:none;
+    }
+    .hero-toast__title{
+      margin:0;
+      font-weight:700;
+      font-size:1.1rem;
+      color:#0f172a;
+    }
+    .hero-toast__message{
+      margin:0;
+      line-height:1.55;
+      color:#1f2937;
+    }
+    .hero-toast__cta{
+      align-self:flex-start;
       display:inline-flex;
       align-items:center;
-      gap:6px;
+      justify-content:center;
+      padding:10px 20px;
+      background:#43D9D7;
+      color:#ffffff;
+      border-radius:999px;
       font-weight:600;
-      color:#000000;
+      transition:background .25s ease, transform .25s ease;
     }
-    .hero-popup__cta:hover,
-    .hero-popup__cta:focus{
-      color:#000000;
+    .hero-toast__cta:hover,
+    .hero-toast__cta:focus{
+      background:#34b8b6;
+      transform:translateY(-1px);
     }
-    .hero-popup__cta svg{width:16px; height:16px;}
+    .hero-toast__cta:focus-visible{
+      outline:0;
+      box-shadow:0 0 0 3px rgba(67,217,215,.35);
+    }
     @media (max-width: 640px){
-      .hero-popup{
-        right:16px;
+      .hero-toast{
         left:16px;
         bottom:16px;
-        max-width:none;
+        border-radius:32px;
+        padding:18px 20px;
       }
     }
     .hero::before{
@@ -576,17 +592,10 @@
 
   <!-- HERO -->
   <main id="home" class="hero">
-    <aside class="hero-popup" role="status" aria-live="polite">
-      <div class="hero-popup__content">
-        <img class="hero-popup__icon" src="SVG/notification.svg" alt="" aria-hidden="true" />
-        <p class="hero-popup__title">Σημαντική ενημέρωση</p>
-        <p class="hero-popup__text">Για κρατήσεις, παρακαλούμε στείλτε μας email με τις επιθυμητές ημερομηνίες άφιξης και αναχώρησης ώστε να σας ενημερώσουμε άμεσα για τη διαθεσιμότητα.</p>
-        <a class="hero-popup__cta" href="mailto:hiddenpearldafnis@gmail.com">
-          Κλείσε τώρα
-          <svg viewBox="0 0 20 20" fill="none" aria-hidden="true"><path d="M4 10h12M11 5l5 5-5 5" stroke="currentColor" stroke-width="1.6" stroke-linecap="round" stroke-linejoin="round"/></svg>
-        </a>
-      </div>
-      <button type="button" class="hero-popup-close" aria-label="Κλείσιμο ειδοποίησης">&times;</button>
+    <aside class="hero-toast" role="status" aria-live="polite" aria-hidden="true">
+      <p class="hero-toast__title">Σημαντική ενημέρωση</p>
+      <p class="hero-toast__message">Για κρατήσεις, παρακαλούμε στείλτε μας email με τις επιθυμητές ημερομηνίες άφιξης και αναχώρησης ώστε να σας ενημερώσουμε άμεσα για τη διαθεσιμότητα.</p>
+      <a class="hero-toast__cta" href="mailto:hiddenpearldafnis@gmail.com">Κλείσε τώρα</a>
     </aside>
     <div class="hero-content container">
       <h1>
@@ -964,22 +973,67 @@
     });
   })();
   (function(){
-    const popup=document.querySelector('.hero-popup');
-    const closeBtn=popup?.querySelector('.hero-popup-close');
-    if(!popup||!closeBtn) return;
-    function hidePopup(){
-      popup.classList.remove('show');
-      popup.classList.add('hide');
-    }
-    closeBtn.addEventListener('click',()=>{
-      hidePopup();
-      popup.addEventListener('transitionend',()=>{popup.style.display='none';},{once:true});
-    });
-    setTimeout(()=>{
-      if(!popup.classList.contains('hide')){
-        popup.classList.add('show');
+    const toast=document.querySelector('.hero-toast');
+    if(!toast) return;
+    const SHOW_DELAY=1000;
+    const HIDE_DELAY=6000;
+    let hideTimer=null;
+    let startTime=0;
+    let remaining=HIDE_DELAY;
+
+    function clearHideTimer(){
+      if(hideTimer){
+        clearTimeout(hideTimer);
+        hideTimer=null;
       }
-    },1000);
+    }
+
+    function beginHide(){
+      if(toast.classList.contains('is-hiding')) return;
+      clearHideTimer();
+      toast.classList.add('is-hiding');
+      toast.setAttribute('aria-hidden','true');
+      toast.addEventListener('transitionend',()=>{
+        toast.classList.remove('is-visible');
+        toast.classList.remove('is-hiding');
+      },{once:true});
+    }
+
+    function startHideTimer(duration){
+      clearHideTimer();
+      remaining=duration;
+      startTime=Date.now();
+      hideTimer=setTimeout(beginHide, duration);
+    }
+
+    function showToast(){
+      toast.classList.add('is-visible');
+      toast.setAttribute('aria-hidden','false');
+      startHideTimer(HIDE_DELAY);
+    }
+
+    function pauseHide(){
+      if(!hideTimer) return;
+      const elapsed=Date.now()-startTime;
+      remaining=Math.max(0, remaining - elapsed);
+      clearHideTimer();
+    }
+
+    function resumeHide(){
+      if(toast.classList.contains('is-hiding')||toast.getAttribute('aria-hidden')==='true') return;
+      if(remaining<=0){
+        beginHide();
+      }else{
+        startHideTimer(remaining);
+      }
+    }
+
+    toast.addEventListener('pointerenter', pauseHide);
+    toast.addEventListener('pointerleave', resumeHide);
+    toast.addEventListener('focusin', pauseHide);
+    toast.addEventListener('focusout', resumeHide);
+
+    setTimeout(showToast, SHOW_DELAY);
   })();
   (function(){
     const widget=document.querySelector('.contact-widget');


### PR DESCRIPTION
## Summary
- restyle the hero notification as a rounded glassmorphism toast anchored to the image
- add a mail CTA button and scripted auto-show/auto-hide behavior with hover pause

## Testing
- not run (static site)


------
https://chatgpt.com/codex/tasks/task_e_68d05e7405ec8320bfb4dd8ce7fcbd90