### PR TITLE
Adjust overlay transparency

### DIFF
--- a/style.css
+++ b/style.css
@@ -2,7 +2,7 @@
   --drawer-width: 300px;
   --drawer-bg: #fff;
   --accent: #43D9D7;
-  --overlay-bg: rgba(0, 0, 0, 0.5);
+  --overlay-bg: rgba(0, 0, 0, 0.3);
 }
 
 body {


### PR DESCRIPTION
## Summary
- reduce the drawer overlay background opacity to make the pop-up background more transparent

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d06560eb0883209e84faf6e0755ac6