### PR TITLE
Make toast background configurable

### DIFF
--- a/index.html
+++ b/index.html
@@ -69,6 +69,7 @@
       --ring: rgba(0,0,0,.1);
       --radius: 18px;
       --shadow: 0 10px 30px rgba(0,0,0,.08);
+      --toast-bg:rgba(255,255,255,.85); /* Transparency can be tuned by editing --toast-bg (e.g., .85 -> .3). */
     }
     html,body{height:100%}
     body{
@@ -134,7 +135,7 @@
       max-width:min(90vw, 340px);
       padding:20px 24px;
       border-radius:50px;
-      background:rgba(255,255,255,.85);
+      background:var(--toast-bg) !important;
       color:#0f172a;
       box-shadow:0 18px 45px rgba(15,23,42,.22);
       backdrop-filter:blur(8px);

--- a/style.css
+++ b/style.css
@@ -3,6 +3,7 @@
   --drawer-bg: #fff;
   --accent: #43D9D7;
   --overlay-bg: rgba(0, 0, 0, 0.5);
+  --toast-bg: rgba(255, 255, 255, 0.85); /* Transparency can be tuned by editing --toast-bg (e.g., .85 -> .3). */
 }
 
 body {


### PR DESCRIPTION
## Summary
- add a --toast-bg CSS variable with guidance on adjusting transparency
- update the hero toast background to reference the shared variable

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68d06ae244988320981f2879c60a5950