### PR TITLE
Fix gallery image loading

### DIFF
--- a/index.html
+++ b/index.html
@@ -674,33 +674,28 @@
         <div class="carousel-track">
           <!-- Replace src with your photos (keep width/height for CLS) -->
           <figure>
-            <a href="images/1.jpg" target="_blank" rel="noopener">
-              <img src="images/1.jpg" alt="Σαλόνι με άνετο καναπέ" loading="lazy" width="800" height="600" />
+            <a href="Gallery/apartment1.png" target="_blank" rel="noopener">
+              <img src="Gallery/apartment1.png" alt="Σαλόνι του Hidden Pearl Dafnis με άνετο καναπέ" width="800" height="600" />
             </a>
           </figure>
           <figure>
-            <a href="images/2.jpg" target="_blank" rel="noopener">
-              <img src="images/2.jpg" alt="Υπνοδωμάτιο με φυσικό φως" loading="lazy" width="800" height="600" />
+            <a href="Gallery/apartment2.png" target="_blank" rel="noopener">
+              <img src="Gallery/apartment2.png" alt="Υπνοδωμάτιο του διαμερίσματος με φυσικό φως" width="800" height="600" />
             </a>
           </figure>
           <figure>
-            <a href="images/3.jpg" target="_blank" rel="noopener">
-              <img src="images/3.jpg" alt="Κουζίνα πλήρως εξοπλισμένη" loading="lazy" width="800" height="600" />
+            <a href="Gallery/apartment3.png" target="_blank" rel="noopener">
+              <img src="Gallery/apartment3.png" alt="Κουζίνα του διαμερίσματος πλήρως εξοπλισμένη" width="800" height="600" />
             </a>
           </figure>
           <figure>
-            <a href="images/4.jpg" target="_blank" rel="noopener">
-              <img src="images/4.jpg" alt="Καθαρό και μοντέρνο μπάνιο" loading="lazy" width="800" height="600" />
+            <a href="Gallery/apartment4.png" target="_blank" rel="noopener">
+              <img src="Gallery/apartment4.png" alt="Μοντέρνο μπάνιο του Hidden Pearl Dafnis" width="800" height="600" />
             </a>
           </figure>
           <figure>
-            <a href="images/5.jpg" target="_blank" rel="noopener">
-              <img src="images/5.jpg" alt="Λεπτομέρειες διακόσμησης" loading="lazy" width="800" height="600" />
-            </a>
-          </figure>
-          <figure>
-            <a href="images/6.jpg" target="_blank" rel="noopener">
-              <img src="images/6.jpg" alt="Μπαλκόνι με θέα στη γειτονιά" loading="lazy" width="800" height="600" />
+            <a href="Gallery/apartment5.png" target="_blank" rel="noopener">
+              <img src="Gallery/apartment5.png" alt="Λεπτομέρειες διακόσμησης στο διαμέρισμα" width="800" height="600" />
             </a>
           </figure>
         </div>


### PR DESCRIPTION
## Summary
- disable lazy-loading on gallery carousel images so all apartment photos render when sliding
- remove the obsolete placeholder slide that pointed to the missing images/6.jpg file

## Testing
- no tests were run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d3b2b4c820832095e24850ea3238b1