### PR TITLE
Fix gallery images rendering

### DIFF
--- a/index.html
+++ b/index.html
@@ -675,27 +675,57 @@
           <!-- Replace src with your photos (keep width/height for CLS) -->
           <figure>
             <a href="Gallery/apartment1.png" target="_blank" rel="noopener">
-
+              <img
+                src="Gallery/apartment1.png"
+                alt="Φωτεινό σαλόνι με καναπέ, τηλεόραση και διακόσμηση"
+                width="450"
+                height="338"
+                loading="lazy"
+              />
             </a>
           </figure>
           <figure>
             <a href="Gallery/apartment2.png" target="_blank" rel="noopener">
-
+              <img
+                src="Gallery/apartment2.png"
+                alt="Κομψή κρεβατοκάμαρα με διπλό κρεβάτι και καθρέφτη"
+                width="338"
+                height="450"
+                loading="lazy"
+              />
             </a>
           </figure>
           <figure>
             <a href="Gallery/apartment3.png" target="_blank" rel="noopener">
-
+              <img
+                src="Gallery/apartment3.png"
+                alt="Ανοιχτή κουζίνα με τραπεζαρία και σύγχρονες συσκευές"
+                width="450"
+                height="338"
+                loading="lazy"
+              />
             </a>
           </figure>
           <figure>
             <a href="Gallery/apartment4.png" target="_blank" rel="noopener">
-
+              <img
+                src="Gallery/apartment4.png"
+                alt="Άνετο υπνοδωμάτιο με φωτισμό και λειτουργικό χώρο εργασίας"
+                width="338"
+                height="450"
+                loading="lazy"
+              />
             </a>
           </figure>
           <figure>
             <a href="Gallery/apartment5.png" target="_blank" rel="noopener">
-
+              <img
+                src="Gallery/apartment5.png"
+                alt="Μοντέρνο μπάνιο με ντους και ποιοτικά υλικά"
+                width="338"
+                height="450"
+                loading="lazy"
+              />
             </a>
           </figure>
         </div>


### PR DESCRIPTION
## Summary
- render each gallery image with visible <img> tags and descriptive alt text
- preserve image aspect ratios with explicit width and height attributes while enabling lazy loading

## Testing
- no automated tests were run (not applicable)

------
https://chatgpt.com/codex/tasks/task_e_68d3bd216b7c8320b6e0ef57f31f276f