### PR TITLE
Adjust gallery images to 800x600

### DIFF
--- a/index.html
+++ b/index.html
@@ -261,8 +261,8 @@
     /* Gallery - Carousel */
     .gallery-carousel{position:relative}
     .carousel-track{display:flex; transition:transform .4s ease; overflow:hidden}
-    .carousel-track figure{flex:0 0 100%; margin:0; overflow:hidden; border-radius:14px; background:#fff; box-shadow:var(--shadow)}
-    .carousel-track img{width:100%; height:240px; object-fit:cover; display:block}
+    .carousel-track figure{flex:0 0 100%; margin:0; overflow:hidden; border-radius:14px; background:#fff; box-shadow:var(--shadow); display:flex; align-items:center; justify-content:center; padding:16px}
+    .carousel-track img{width:min(100%,800px); aspect-ratio:4/3; height:auto; object-fit:cover; display:block; border-radius:12px}
     .carousel-btn{position:absolute; top:50%; transform:translateY(-50%); border:0; background:#fff; width:36px; height:36px; border-radius:999px; box-shadow:var(--shadow); cursor:pointer; display:flex; align-items:center; justify-content:center}
     .carousel-btn:focus{outline:none; box-shadow:0 0 0 3px var(--ring)}
     .carousel-btn.prev{left:8px}
@@ -678,7 +678,8 @@
               <img
                 src="Gallery/apartment1.png"
                 alt="Φωτεινό σαλόνι με καναπέ, τηλεόραση και διακόσμηση"
-
+                width="800"
+                height="600"
                 loading="lazy"
               />
             </a>
@@ -688,7 +689,8 @@
               <img
                 src="Gallery/apartment2.png"
                 alt="Κομψή κρεβατοκάμαρα με διπλό κρεβάτι και καθρέφτη"
-
+                width="800"
+                height="600"
                 loading="lazy"
               />
             </a>
@@ -698,7 +700,8 @@
               <img
                 src="Gallery/apartment3.png"
                 alt="Ανοιχτή κουζίνα με τραπεζαρία και σύγχρονες συσκευές"
-
+                width="800"
+                height="600"
                 loading="lazy"
               />
             </a>
@@ -708,7 +711,8 @@
               <img
                 src="Gallery/apartment4.png"
                 alt="Άνετο υπνοδωμάτιο με φωτισμό και λειτουργικό χώρο εργασίας"
-
+                width="800"
+                height="600"
                 loading="lazy"
               />
             </a>
@@ -718,7 +722,8 @@
               <img
                 src="Gallery/apartment5.png"
                 alt="Μοντέρνο μπάνιο με ντους και ποιοτικά υλικά"
-
+                width="800"
+                height="600"
                 loading="lazy"
               />
             </a>


### PR DESCRIPTION
## Summary
- update the gallery carousel styling so each slide centers an 800x600 image
- add explicit width and height attributes to the five apartment photos

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d56402157c8320ad307060b3b10f02