### PR TITLE
Adjust hero layout ratio and background behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -124,12 +124,18 @@
       display:flex;
       align-items:center;
       justify-content:center;
-      min-height:70vh;
+      aspect-ratio: 4 / 3;
+      padding-block: clamp(64px, 10vw, 120px);
       overflow:hidden;
       --hero-bg:url("images/hiddenpearl1.jpg");
       --hero-bg-next:var(--hero-bg);
       color:#fff;
-      background:var(--hero-bg) center/cover no-repeat;
+      background:var(--hero-bg) center/contain no-repeat;
+    }
+    @supports not (aspect-ratio: 1) {
+      .hero{
+        min-height:70vh;
+      }
     }
     .hero-toast{
       position:absolute;
@@ -214,7 +220,7 @@
       content:"";
       position:absolute;
       inset:0;
-      background:var(--hero-bg-next) center/cover no-repeat;
+      background:var(--hero-bg-next) center/contain no-repeat;
       opacity:0;
       transition:opacity 1s ease;
       z-index:0;


### PR DESCRIPTION
## Summary
- replace the hero's fixed minimum height with a 4:3 aspect ratio and responsive padding so the content keeps spacing
- switch hero background layers to use contain sizing for consistent cross-fade alignment and add an aspect-ratio fallback for older browsers

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68d5b18b438c8320ab5395a630d1a82e