### PR TITLE
Convert gallery to scroll snap carousel

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,6 +55,9 @@
   <!-- Fonts -->
   <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
   <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;600;700&display=swap" rel="stylesheet">
+  <link rel="preload" href="gallery/boutique1.jpg" as="image" fetchpriority="high" />
+  <link rel="preload" href="gallery/boutique2.jpg" as="image" />
+  <link rel="preload" href="gallery/boutique3.jpg" as="image" />
 
   <style>
     :root{
@@ -280,19 +283,73 @@
     .general-info:hover,
     .general-info:focus-within{transform:translateY(-6px); box-shadow:0 18px 40px rgba(0,0,0,.12)}
 
-    /* Gallery - Carousel */
+    /* Gallery - Scroll Snap Carousel */
     .gallery-carousel{position:relative}
-    .carousel-track{display:flex; transition:transform .4s ease; overflow:hidden}
-    .carousel-track .gallery-slide{flex:0 0 100%; margin:0; overflow:hidden; border-radius:14px; background:#fff; box-shadow:var(--shadow); display:flex; align-items:center; justify-content:center; padding:16px}
-    .gallery-slide__link{display:flex; width:100%; height:100%; align-items:center; justify-content:center}
-    .carousel-track .gallery-slide__image{width:min(100%,800px); aspect-ratio:4/3; height:auto; object-fit:cover; display:block; border-radius:12px}
-    .carousel-btn{position:absolute; top:50%; transform:translateY(-50%); border:0; background:#fff; width:36px; height:36px; border-radius:999px; box-shadow:var(--shadow); cursor:pointer; display:flex; align-items:center; justify-content:center}
-    .carousel-btn:focus{outline:none; box-shadow:0 0 0 3px var(--ring)}
-    .carousel-btn.prev{left:8px}
-    .carousel-btn.next{right:8px}
-    .carousel-dots{display:flex; gap:6px; justify-content:center; margin-top:12px}
-    .carousel-dots button{width:8px; height:8px; border-radius:999px; border:0; background:var(--muted); opacity:.4; cursor:pointer}
-    .carousel-dots button.active{opacity:1; background:var(--btn)}
+    .gallery-track{
+      --gallery-gap:clamp(14px, 4vw, 26px);
+      --visible:3;
+      display:flex;
+      gap:var(--gallery-gap);
+      overflow-x:auto;
+      padding-block:12px 4px;
+      margin-inline:calc(-1 * clamp(16px, 5vw, 48px));
+      padding-inline:clamp(16px, 5vw, 48px);
+      scroll-snap-type:x mandatory;
+      scroll-padding-inline:clamp(16px, 5vw, 48px);
+      scroll-behavior:smooth;
+      -webkit-overflow-scrolling:touch;
+      scrollbar-width:thin;
+      scrollbar-color:rgba(15,23,42,.2) transparent;
+    }
+    .gallery-track::-webkit-scrollbar{height:8px}
+    .gallery-track::-webkit-scrollbar-track{background:transparent}
+    .gallery-track::-webkit-scrollbar-thumb{background:rgba(15,23,42,.18); border-radius:999px}
+    .gallery-slide{
+      flex:0 0 calc((100% - (var(--gallery-gap) * (var(--visible) - 1))) / var(--visible));
+      margin:0;
+      background:var(--card);
+      border-radius:14px;
+      box-shadow:0 16px 36px rgba(15,23,42,.12);
+      overflow:hidden;
+      position:relative;
+      scroll-snap-align:center;
+      scroll-snap-stop:always;
+      transform:scale(.98);
+      transition:transform .45s ease, box-shadow .45s ease;
+    }
+    .gallery-slide::before{
+      content:"";
+      position:absolute;
+      inset:0;
+      border-radius:inherit;
+      pointer-events:none;
+      box-shadow:inset 0 0 0 1px rgba(15,23,42,.05);
+      opacity:.6;
+    }
+    .gallery-slide.is-active{
+      transform:scale(1.06);
+      box-shadow:0 28px 56px rgba(15,23,42,.22);
+    }
+    .gallery-slide__image{
+      width:100%;
+      height:260px;
+      object-fit:cover;
+      display:block;
+      border-radius:14px;
+      transition:transform .45s ease;
+    }
+    .gallery-slide.is-active .gallery-slide__image{transform:scale(1.02)}
+    @media (max-width:1024px){
+      .gallery-track{--visible:3}
+    }
+    @media (max-width:920px){
+      .gallery-track{--visible:2}
+      .gallery-slide__image{height:220px}
+    }
+    @media (max-width:640px){
+      .gallery-track{--visible:1}
+      .gallery-slide__image{height:200px}
+    }
 
     /* Lightbox */
     .lightbox{position:fixed; inset:0; background:rgba(0,0,0,.85); display:none; align-items:center; justify-content:center; z-index:100}
@@ -693,102 +750,173 @@
       <h2 id="photos" class="section-title">Φωτογραφίες</h2>
       <p class="section-sub">Ρεαλιστικές εικόνες του χώρου – έτοιμες για εντυπωσιασμό.</p>
       <div class="gallery-carousel" id="gal">
-        <button class="carousel-btn prev" aria-label="Previous photo">&#10094;</button>
-        <div class="carousel-track">
-          <!-- Replace src with your photos (keep width/height for CLS) -->
-          <figure class="gallery-slide">
-            <a
-              href="Gallery/apartment1.png"
-              target="_blank"
-              rel="noopener"
-              class="gallery-slide__link"
-              aria-label="Μεγέθυνση φωτογραφίας φωτεινού σαλονιού"
-            >
-              <img
-                src="Gallery/apartment1.png"
-                class="gallery-slide__image"
-                alt="Φωτεινό σαλόνι με καναπέ, τηλεόραση και διακόσμηση"
-                width="800"
-                height="600"
-                loading="lazy"
-              />
-            </a>
+        <div class="gallery-track" role="list">
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique1.jpg" class="gallery-slide__image" alt="Φωτεινό σαλόνι με καναπέ, τηλεόραση και διακόσμηση" loading="eager" fetchpriority="high" decoding="async" />
           </figure>
-          <figure class="gallery-slide">
-            <a
-              href="Gallery/apartment2.png"
-              target="_blank"
-              rel="noopener"
-              class="gallery-slide__link"
-              aria-label="Μεγέθυνση φωτογραφίας κρεβατοκάμαρας"
-            >
-              <img
-                src="Gallery/apartment2.png"
-                class="gallery-slide__image"
-                alt="Κομψή κρεβατοκάμαρα με διπλό κρεβάτι και καθρέφτη"
-                width="800"
-                height="600"
-                loading="lazy"
-              />
-            </a>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique2.jpg" class="gallery-slide__image" alt="Κομψή κρεβατοκάμαρα με διπλό κρεβάτι και καθρέφτη" loading="eager" fetchpriority="high" decoding="async" />
           </figure>
-          <figure class="gallery-slide">
-            <a
-              href="Gallery/apartment3.png"
-              target="_blank"
-              rel="noopener"
-              class="gallery-slide__link"
-              aria-label="Μεγέθυνση φωτογραφίας κουζίνας"
-            >
-              <img
-                src="Gallery/apartment3.png"
-                class="gallery-slide__image"
-                alt="Ανοιχτή κουζίνα με τραπεζαρία και σύγχρονες συσκευές"
-                width="800"
-                height="600"
-                loading="lazy"
-              />
-            </a>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique3.jpg" class="gallery-slide__image" alt="Ανοιχτή κουζίνα με τραπεζαρία και σύγχρονες συσκευές" loading="eager" decoding="async" />
           </figure>
-          <figure class="gallery-slide">
-            <a
-              href="Gallery/apartment4.png"
-              target="_blank"
-              rel="noopener"
-              class="gallery-slide__link"
-              aria-label="Μεγέθυνση φωτογραφίας δευτέρου υπνοδωματίου"
-            >
-              <img
-                src="Gallery/apartment4.png"
-                class="gallery-slide__image"
-                alt="Άνετο υπνοδωμάτιο με φωτισμό και λειτουργικό χώρο εργασίας"
-                width="800"
-                height="600"
-                loading="lazy"
-              />
-            </a>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique4.jpg" class="gallery-slide__image" alt="Άνετο υπνοδωμάτιο με φωτισμό και λειτουργικό χώρο εργασίας" loading="lazy" decoding="async" />
           </figure>
-          <figure class="gallery-slide">
-            <a
-              href="Gallery/apartment5.png"
-              target="_blank"
-              rel="noopener"
-              class="gallery-slide__link"
-              aria-label="Μεγέθυνση φωτογραφίας μπάνιου"
-            >
-              <img
-                src="Gallery/apartment5.png"
-                class="gallery-slide__image"
-                alt="Μοντέρνο μπάνιο με ντους και ποιοτικά υλικά"
-                width="800"
-                height="600"
-                loading="lazy"
-              />
-            </a>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique5.jpg" class="gallery-slide__image" alt="Μοντέρνο μπάνιο με ντους και ποιοτικά υλικά" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique6.jpg" class="gallery-slide__image" alt="Boutique photo 6" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique7.jpg" class="gallery-slide__image" alt="Boutique photo 7" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique8.jpg" class="gallery-slide__image" alt="Boutique photo 8" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique9.jpg" class="gallery-slide__image" alt="Boutique photo 9" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique10.jpg" class="gallery-slide__image" alt="Boutique photo 10" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique11.jpg" class="gallery-slide__image" alt="Boutique photo 11" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique12.jpg" class="gallery-slide__image" alt="Boutique photo 12" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique13.jpg" class="gallery-slide__image" alt="Boutique photo 13" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique14.jpg" class="gallery-slide__image" alt="Boutique photo 14" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique15.jpg" class="gallery-slide__image" alt="Boutique photo 15" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique16.jpg" class="gallery-slide__image" alt="Boutique photo 16" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique17.jpg" class="gallery-slide__image" alt="Boutique photo 17" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique18.jpg" class="gallery-slide__image" alt="Boutique photo 18" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique19.jpg" class="gallery-slide__image" alt="Boutique photo 19" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique20.jpg" class="gallery-slide__image" alt="Boutique photo 20" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique21.jpg" class="gallery-slide__image" alt="Boutique photo 21" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique22.jpg" class="gallery-slide__image" alt="Boutique photo 22" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique23.jpg" class="gallery-slide__image" alt="Boutique photo 23" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique24.jpg" class="gallery-slide__image" alt="Boutique photo 24" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique25.jpg" class="gallery-slide__image" alt="Boutique photo 25" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique26.jpg" class="gallery-slide__image" alt="Boutique photo 26" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique27.jpg" class="gallery-slide__image" alt="Boutique photo 27" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique28.jpg" class="gallery-slide__image" alt="Boutique photo 28" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique29.jpg" class="gallery-slide__image" alt="Boutique photo 29" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique30.jpg" class="gallery-slide__image" alt="Boutique photo 30" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique31.jpg" class="gallery-slide__image" alt="Boutique photo 31" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique32.jpg" class="gallery-slide__image" alt="Boutique photo 32" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique33.jpg" class="gallery-slide__image" alt="Boutique photo 33" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique34.jpg" class="gallery-slide__image" alt="Boutique photo 34" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique35.jpg" class="gallery-slide__image" alt="Boutique photo 35" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique36.jpg" class="gallery-slide__image" alt="Boutique photo 36" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique37.jpg" class="gallery-slide__image" alt="Boutique photo 37" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique38.jpg" class="gallery-slide__image" alt="Boutique photo 38" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique39.jpg" class="gallery-slide__image" alt="Boutique photo 39" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique40.jpg" class="gallery-slide__image" alt="Boutique photo 40" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique41.jpg" class="gallery-slide__image" alt="Boutique photo 41" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique42.jpg" class="gallery-slide__image" alt="Boutique photo 42" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique43.jpg" class="gallery-slide__image" alt="Boutique photo 43" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique44.jpg" class="gallery-slide__image" alt="Boutique photo 44" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique45.jpg" class="gallery-slide__image" alt="Boutique photo 45" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique46.jpg" class="gallery-slide__image" alt="Boutique photo 46" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique47.jpg" class="gallery-slide__image" alt="Boutique photo 47" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique48.jpg" class="gallery-slide__image" alt="Boutique photo 48" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique49.jpg" class="gallery-slide__image" alt="Boutique photo 49" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique50.jpg" class="gallery-slide__image" alt="Boutique photo 50" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique51.jpg" class="gallery-slide__image" alt="Boutique photo 51" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique52.jpg" class="gallery-slide__image" alt="Boutique photo 52" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique53.jpg" class="gallery-slide__image" alt="Boutique photo 53" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique54.jpg" class="gallery-slide__image" alt="Boutique photo 54" loading="lazy" decoding="async" />
+          </figure>
+          <figure class="gallery-slide" role="listitem">
+            <img src="gallery/boutique55.jpg" class="gallery-slide__image" alt="Boutique photo 55" loading="lazy" decoding="async" />
           </figure>
         </div>
-        <button class="carousel-btn next" aria-label="Next photo">&#10095;</button>
-        <div class="carousel-dots" aria-hidden="true"></div>
       </div>
     </div>
   </section>
@@ -976,27 +1104,64 @@
   (function(){
     const carousel=document.querySelector('#gal');
     if(!carousel) return;
-    const track=carousel.querySelector('.carousel-track');
-    const slides=Array.from(track.children);
-    const prev=carousel.querySelector('.carousel-btn.prev');
-    const next=carousel.querySelector('.carousel-btn.next');
-    const dotsNav=carousel.querySelector('.carousel-dots');
-    slides.forEach((_,i)=>{
-      const btn=document.createElement('button');
-      if(i===0) btn.classList.add('active');
-      dotsNav.appendChild(btn);
-      btn.addEventListener('click',()=>goToSlide(i));
+    const track=carousel.querySelector('.gallery-track');
+    if(!track) return;
+    const slides=Array.from(track.querySelectorAll('.gallery-slide'));
+    if(!slides.length) return;
+
+    let activeSlide=slides[0];
+    activeSlide.classList.add('is-active');
+
+    const thresholds=Array.from({length:101}, (_,i)=>i/100);
+    const visibilityRatios=new Map();
+
+    const updateActive=()=>{
+      if(!visibilityRatios.size) return;
+      let mostVisible=activeSlide;
+      let maxRatio=-1;
+      visibilityRatios.forEach((ratio, target)=>{
+        if(ratio>maxRatio){
+          maxRatio=ratio;
+          mostVisible=target;
+        }
+      });
+      if(mostVisible!==activeSlide){
+        activeSlide.classList.remove('is-active');
+        mostVisible.classList.add('is-active');
+        activeSlide=mostVisible;
+      }else if(!activeSlide.classList.contains('is-active')){
+        activeSlide.classList.add('is-active');
+      }
+    };
+
+    const observer=new IntersectionObserver(entries=>{
+      entries.forEach(entry=>{
+        if(entry.isIntersecting){
+          visibilityRatios.set(entry.target, entry.intersectionRatio);
+        }else{
+          visibilityRatios.delete(entry.target);
+        }
+      });
+      updateActive();
+    },{
+      root:track,
+      threshold:thresholds
     });
-    const dots=Array.from(dotsNav.children);
-    let index=0;
-    function goToSlide(i){
-      index=(i+slides.length)%slides.length;
-      track.style.transform=`translateX(-${index*100}%)`;
-      dots.forEach(d=>d.classList.remove('active'));
-      dots[index].classList.add('active');
-    }
-    prev.addEventListener('click',()=>goToSlide(index-1));
-    next.addEventListener('click',()=>goToSlide(index+1));
+
+    slides.forEach(slide=>observer.observe(slide));
+
+    let ticking=false;
+    const handleScroll=()=>{
+      if(ticking) return;
+      ticking=true;
+      requestAnimationFrame(()=>{
+        updateActive();
+        ticking=false;
+      });
+    };
+
+    track.addEventListener('scroll', handleScroll, {passive:true});
+    window.addEventListener('resize', handleScroll);
   })();
   (function(){
     const carousel=document.querySelector('.testimonials-carousel');


### PR DESCRIPTION
## Summary
- replace the gallery markup with a scroll-snap carousel that includes all boutique1–boutique55 images
- add responsive styling for the horizontal track, snap points, and active slide scale/box-shadow effects
- preload the first gallery images and use IntersectionObserver to flag the most visible slide

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d5b5aa322083208d02840c32092ac7